### PR TITLE
removed iptables-persistent from Depends to improve usablity

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Vcs-Git: git://git.qubes-os.org/marmarek/core-agent-linux.git
 
 Package: qubes-core-agent
 Architecture: any
-Depends: qubes-utils (>= 3.0.1), libvchan-xen, xenstore-utils, iptables-persistent, xserver-xorg-video-dummy, xen-utils-common, ethtool, python2.7, python-gi, init-system-helpers, xdg-user-dirs, iptables, net-tools, initscripts, imagemagick, fakeroot, systemd, locales, sudo, dmsetup, psmisc, ncurses-term, xserver-xorg-core, x11-xserver-utils, xinit, ${shlibs:Depends}, ${misc:Depends}
+Depends: qubes-utils (>= 3.0.1), libvchan-xen, xenstore-utils, xserver-xorg-video-dummy, xen-utils-common, ethtool, python2.7, python-gi, init-system-helpers, xdg-user-dirs, iptables, net-tools, initscripts, imagemagick, fakeroot, systemd, locales, sudo, dmsetup, psmisc, ncurses-term, xserver-xorg-core, x11-xserver-utils, xinit, ${shlibs:Depends}, ${misc:Depends}
 Recommends: tinyproxy, gnome-themes-standard, xsettingsd, gnome-packagekit, chrony, ntpdate, network-manager (>= 0.8.1-1), network-manager-gnome, haveged, libnotify-bin, notify-osd, gnome-terminal, python-nautilus, yum, yum-utils
 Conflicts: qubes-core-agent-linux, firewalld, qubes-core-vm-sysvinit
 Description: Qubes core agent


### PR DESCRIPTION
qubes-core-agent `Depends:` on `iptables-persistent`. (https://github.com/QubesOS/qubes-core-agent-linux/blob/ea0615d4da0ce9f06dc0ce8fe918a3c39df59c39/debian/control#L12)

Is this necessary?

It causes an usability issue on suite upgrades.

How to manually trigger:
```
sudo apt-get install --reinstall iptables-persistent
```

Causes a very difficult questions for users.

```
Package configuration                                                                                                 
 ┌───────────────────────────────────────┤ Configuring iptables-persistent ├───────────────────────────────────────┐  
 │                                                                                                                 │  
 │ Current iptables rules can be saved to the configuration file /etc/iptables/rules.v4. These rules will then be  │  
 │ loaded automatically during system startup.                                                                     │  
 │                                                                                                                 │  
 │ Rules are only saved automatically during package installation. See the manual page of iptables-save(8) for     │  
 │ instructions on keeping the rules file up-to-date.                                                              │  
 │                                                                                                                 │  
 │ Save current IPv4 rules?                                                                                        │  
 │                                                                                                                 │  
 │                                 <Yes>                                    <No>                                   │  
 │                                                                                                                 │  
 └─────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘  
```

(Followed by another debconf question for IPv6 rules.)