### PR TITLE
qfile-unpacker: Avoid data loss by checking for child errors

### DIFF
--- a/qubes-rpc/qfile-unpacker.c
+++ b/qubes-rpc/qfile-unpacker.c
@@ -90,5 +90,8 @@ int main(int argc __attribute((__unused__)), char ** argv __attribute__((__unuse
 	}
 	if (umount2(".", MNT_DETACH) < 0)
 		gui_fatal("Cannot umount incoming directory");
-	return ret;
+	if (!WIFEXITED(ret)) {
+		gui_fatal("Child process exited abnormally");
+	}
+	return WEXITSTATUS(ret);
 }


### PR DESCRIPTION
When qfile-unpacker's child encountered an error, it would display an
error message and exit(1), but the parent didn't inspect its status and
exited successfully.

That was unfortunate for qvm-move-to-vm: Even if the destination VM e.g.
didn't have enough free disk space, the RPC call would claim to succeed
anyway, so the file would be deleted from the source VM.