### PR TITLE
Let ntpdate use the ntp servers received by dhcp options

### DIFF
--- a/network/qubes-nmhook
+++ b/network/qubes-nmhook
@@ -7,3 +7,10 @@ if [ -x /bin/systemctl ]; then
 else
     /usr/sbin/service qubes-updates-proxy try-restart
 fi
+
+# Let ntpdate use the ntp servers received by dhcp options:
+if [ -z "${DHCP4_NTP_SERVERS}" ]; then
+    echo "pool.ntp.org" > /etc/ntp/step-tickers
+else
+    echo ${DHCP4_NTP_SERVERS} |tr '[[:space:]]' '\n' > /etc/ntp/step-tickers
+fi


### PR DESCRIPTION
NetworkManager (by default) do not care about ntp servers received by dhcp options
This patch help to distribute the NTP servers - at least for ntpdate, which is used by qvm-sync-clock
