### PR TITLE
Improve qvm-run

### DIFF
--- a/qubes-rpc/qvm-run
+++ b/qubes-rpc/qvm-run
@@ -21,7 +21,7 @@
 #
 
 if [ $# -lt 2 ] ; then
-	cat <<USAGE
+    cat <<USAGE
 Usage: $0 vmname command arguments
 Executes a command in another VM using the qubes.VMShell RPC service.  The
 arguments are joined with spaces and passed to "bash -c".
@@ -33,11 +33,11 @@ is your terminal.
 
 You can use \$dispvm or --dispvm instead of vmname to start a new DisposableVM.
 USAGE
-	exit 1
+    exit 1
 fi
 VMNAME=$1
 shift
 if [ $VMNAME = "--dispvm" ] ; then
-	VMNAME='$dispvm'
+    VMNAME='$dispvm'
 fi
 exec /usr/lib/qubes/qrexec-client-vm $VMNAME qubes.VMShell "/usr/lib/qubes/qrun-in-vm" "$@"

--- a/qubes-rpc/qvm-run
+++ b/qubes-rpc/qvm-run
@@ -40,10 +40,10 @@ if [ $# -lt 2 ] ; then
     exit 1
 fi
 
-VMNAME=$1
+VMNAME="$1"
 shift
 
-if [ $VMNAME = "--dispvm" ] ; then
+if [ "$VMNAME" = "--dispvm" ] ; then
     VMNAME='$dispvm'
 fi
-exec /usr/lib/qubes/qrexec-client-vm $VMNAME qubes.VMShell "/usr/lib/qubes/qrun-in-vm" "$@"
+exec /usr/lib/qubes/qrexec-client-vm "$VMNAME" qubes.VMShell "/usr/lib/qubes/qrun-in-vm" "$@"

--- a/qubes-rpc/qvm-run
+++ b/qubes-rpc/qvm-run
@@ -45,5 +45,8 @@ shift
 
 if [ "$VMNAME" = "--dispvm" ] ; then
     VMNAME='$dispvm'
+elif [ "$VMNAME" = "" ] ; then
+    print_usage
+    exit 1
 fi
 exec /usr/lib/qubes/qrexec-client-vm "$VMNAME" qubes.VMShell "/usr/lib/qubes/qrun-in-vm" "$@"

--- a/qubes-rpc/qvm-run
+++ b/qubes-rpc/qvm-run
@@ -20,8 +20,8 @@
 #
 #
 
-if [ $# -lt 2 ] ; then
-    cat <<USAGE
+function print_usage(){
+cat >&2 <<USAGE
 Usage: $0 vmname command arguments
 Executes a command in another VM using the qubes.VMShell RPC service.  The
 arguments are joined with spaces and passed to "bash -c".
@@ -33,10 +33,16 @@ is your terminal.
 
 You can use \$dispvm or --dispvm instead of vmname to start a new DisposableVM.
 USAGE
+}
+
+if [ $# -lt 2 ] ; then
+    print_usage
     exit 1
 fi
+
 VMNAME=$1
 shift
+
 if [ $VMNAME = "--dispvm" ] ; then
     VMNAME='$dispvm'
 fi


### PR DESCRIPTION
-Properly quote variable names.
-Properly handle empty domain name.
-Print usage information to stderr.
-Follow coding guidelines WRT tabs/spaces.