### PR TITLE
Fix forcesize (rsvg-convert does not scale up)

### DIFF
--- a/qubes-rpc/qubes.GetImageRGBA
+++ b/qubes-rpc/qubes.GetImageRGBA
@@ -5,7 +5,7 @@ ICON_MAXSIZE=512
 
 if [ "${filename%%:*}" = xdgicon ]; then
     filename="$(/usr/lib/qubes/xdg-icon "${filename#*:}" "$ICON_MAXSIZE")"
-    forcesize="$ICON_MAXSIZE"
+    #forcesize="$ICON_MAXSIZE"
 
     [ -n "${filename}" ]
 elif [ "${filename}" = "-" ] || [ "${filename##*:}" = "-" ]; then


### PR DESCRIPTION
Problem is that (at least in Dom0 with XFCE) many icons (for example for newly installed apps Thunar, Meld, etc.) are blank with a spot on the top-left. Upon inspection with image viewer, these icons are 512x512 and the "spot on the top-left" is the actual icon with size 48x48.

The problem is that "rsvg-convert" (used in line 33) doesn't work as expected when forcing a larger size than in the input file: it doesn't scale it up, so icons end up being a small 48x48 square on the top left of the final image of 512x512 (ICON_MAXSIZE)

Applying this change in a TemplateVM Terminal ("fedora-23" in my case) with command: sudo gedit /etc/qubes-rpc/qubes.GetImageRGBA
I can then go to a Dom0 Terminal and re-generate the wrong icons by doing: /usr/libexec/qubes-appmenus/qubes-receive-appmenus fedora-23

Now all the newly installed apps' icons are fine.

However, there are a couple of corner cases when the xdg-icon returns svg icons with height/width larger than 512 (like git-cola and git-dag), so another change is proposed to repo "qubes-linux-utils" file: core/imgconverter.py to allow an ICON_MAXSIZE of 1024 (instead of 512).