### PR TITLE
Remove exec in last line of qvm-copy-to-vm

### DIFF
--- a/qubes-rpc/qvm-copy-to-vm
+++ b/qubes-rpc/qvm-copy-to-vm
@@ -40,4 +40,4 @@ if [ $PROGRESS_TYPE = console ] ; then
 	export FILECOPY_TOTAL_SIZE=$(du --apparent-size -c -- "$@" 2> /dev/null | tail -1 | cut -f 1)
 fi
 
-exec /usr/lib/qubes/qrexec-client-vm $VM qubes.Filecopy /usr/lib/qubes/qfile-agent "$@"
+/usr/lib/qubes/qrexec-client-vm $VM qubes.Filecopy /usr/lib/qubes/qfile-agent "$@"


### PR DESCRIPTION
Should have been part of #10, otherwise qvm-move-to-vm won't remove the files after copying. Sorry about that.