### PR TITLE
Fallback to zenity if kdialog not available

### DIFF
--- a/qubes-rpc/qvm-copy-to-vm.kde
+++ b/qubes-rpc/qvm-copy-to-vm.kde
@@ -20,21 +20,35 @@
 #
 #
 
+if type kdialog 2> /dev/null; then
+kdlg=1
+else kdlg=0
+fi
+
+if [ $kdlg -eq 1 ] ; then
 VM=$(kdialog -inputbox "Enter the VM name to send files to:")
+else
+VM=$(zenity --entry --text="Enter the VM name to send files to:")
+fi
+
 if [ X$VM = X ] ; then exit 0 ; fi
 
 SIZE=$(du --apparent-size -c -- "$@" 2> /dev/null | tail -1 | cut -f 1)
+if [ $kdlg -eq 1 ] ;then
 REF=$(kdialog --progressbar "Copy progress")
+fi
 qdbus $REF org.freedesktop.DBus.Properties.Set "" maximum $SIZE
 
 export PROGRESS_TYPE=gui
 
 /usr/lib/qubes/qrexec-client-vm $VM qubes.Filecopy \
 	/usr/lib/qubes/qfile-agent "$@" |
+if [ $kdlg -eq 1 ] ;then
 (while read sentsize ; do
 	CURRSIZE=$(($sentsize/1024))
 	qdbus $REF  org.freedesktop.DBus.Properties.Set "" value $CURRSIZE
 done)
+fi
 
 qdbus $REF close
 # we do not want a dozen error messages, do we

--- a/qubes-rpc/qvm-move-to-vm.kde
+++ b/qubes-rpc/qvm-move-to-vm.kde
@@ -20,11 +20,23 @@
 #
 #
 
+if type kdialog 2> /dev/null; then
+kdlg=1
+else kdlg=0
+fi
+
+if [ $kdlg -eq 1 ] ; then
 VM=$(kdialog -inputbox "Enter the VM name to send files to:")
+else
+VM=$(zenity --entry --text="Enter the VM name to send files to:")
+fi
+
 if [ X$VM = X ] ; then exit 0 ; fi
 
 SIZE=$(du --apparent-size -c -- "$@" 2> /dev/null | tail -1 | cut -f 1)
+if [ $kdlg -eq 1 ] ;then
 REF=$(kdialog --progressbar "Move progress")
+fi
 qdbus $REF org.freedesktop.DBus.Properties.Set "" maximum $SIZE
 
 export PROGRESS_TYPE=gui
@@ -32,10 +44,13 @@ export PROGRESS_TYPE=gui
 set -o pipefail
 /usr/lib/qubes/qrexec-client-vm $VM qubes.Filecopy \
 	/usr/lib/qubes/qfile-agent "$@" |
+if [ $kdlg -eq 1 ] ;then
 (while read sentsize ; do
 	CURRSIZE=$(($sentsize/1024))
 	qdbus $REF  org.freedesktop.DBus.Properties.Set "" value $CURRSIZE
 done)
+fi
+
 if [ $? -eq 0 ]; then
     rm -rf "$@"
 fi


### PR DESCRIPTION
The issue with dolphin identified in https://github.com/QubesOS/qubes-issues/issues/1429 arises because kdialog isn't installed in debian template. It can't be made a dependency of the core-agent package as it pulls a ridiculous amount of kde stuff with it.
This quick fix closes issue with dolphin.