### PR TITLE
Order network management units after network-pre.target

### DIFF
--- a/vm-systemd/qubes-misc-post.service
+++ b/vm-systemd/qubes-misc-post.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Qubes misc post-boot actions
-After=qubes-dvm.service qubes-mount-dirs.service
+After=network-pre.target qubes-dvm.service qubes-mount-dirs.service
 
 [Service]
 Type=oneshot

--- a/vm-systemd/qubes-netwatcher.service
+++ b/vm-systemd/qubes-netwatcher.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Qubes network monitor
 ConditionPathExists=/var/run/qubes-service/qubes-netwatcher
-After=qubes-firewall.service
+After=network-pre.target qubes-firewall.service
 
 [Service]
 ExecStart=/usr/sbin/qubes-netwatcher

--- a/vm-systemd/qubes-network.service
+++ b/vm-systemd/qubes-network.service
@@ -2,7 +2,7 @@
 Description=Qubes network forwarding setup
 ConditionPathExists=/var/run/qubes-service/qubes-network
 Before=network.target
-After=qubes-iptables.service
+After=network-pre.target qubes-iptables.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Network management software should order itself after network-pre.target
(man 7 systemd.special) so that other units can order themselves before
the *beginning* of network initialization. (qubes-misc-post too because
it calls setup-ip.)

Relevant for QubesOS/qubes-issues#2108