### PR TITLE
Add systemd override for haveged in xenial and stretch. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -263,6 +263,11 @@ else
 	install -m 0644 misc/py2/xdg.py* $(DESTDIR)/$(PYTHON_SITEARCH)/qubes/
 endif
 
+ifneq (,$(filter xenial stretch, $(shell lsb_release -cs)))
+	mkdir -p $(DESTDIR)/etc/systemd/system/
+	install -m 0644 vm-systemd/haveged.service  $(DESTDIR)/etc/systemd/system/
+endif
+
 	install -d $(DESTDIR)/mnt/removable
 
 	install -D -m 0644 misc/xorg-preload-apps.conf $(DESTDIR)/etc/X11/xorg-preload-apps.conf

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -111,6 +111,7 @@ case "${1}" in
             # Maybe install overridden serial.conf init script
             installSerialConf
         fi
+        systemctl reenable haveged
 
         debug "UPDATE..."
         # disable some Upstart services

--- a/vm-systemd/haveged.service
+++ b/vm-systemd/haveged.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Entropy daemon using the HAVEGE algorithm
+Documentation=man:haveged(8) http://www.issihosts.com/haveged/
+DefaultDependencies=no
+ConditionVirtualization=!container
+After=apparmor.service systemd-random-seed.service systemd-tmpfiles-setup.service
+
+[Service]
+EnvironmentFile=/etc/default/haveged
+ExecStart=/usr/sbin/haveged --Foreground --verbose=1 $DAEMON_ARGS
+SuccessExitStatus=143
+SecureBits=noroot-locked
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_SYS_ADMIN
+PrivateTmp=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
QubesOS/qubes-issues#2161 - 
Issue arises in both stretch and xenial. Solution is to provide override file, changing ordering of startup.
Reenable haveged.service after Debian package installation, to force new link in multi-user.target.wants after upgrade.

