### PR TITLE
(vm) qvm-move-to-vm: don't "rm -rf" vm name argument

### DIFF
--- a/qubes-rpc/qvm-move-to-vm
+++ b/qubes-rpc/qvm-move-to-vm
@@ -21,4 +21,5 @@
 #
 
 . qvm-copy-to-vm "$@" &&
+shift &&
 rm -rf -- "$@"


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#2472 from commit
3f600d03fa7069933726ae577da3fcb47845b064