### PR TITLE
Introduce $QREXEC_REMOTE_DOMAIN_*ID* in VMs

### DIFF
--- a/qrexec/qrexec-agent-data.c
+++ b/qrexec/qrexec-agent-data.c
@@ -57,13 +57,16 @@ static void sigusr1_handler(int __attribute__((__unused__))x)
     signal(SIGUSR1, SIG_IGN);
 }
 
-void prepare_child_env() {
+void prepare_child_env(int remote_domid) {
     char pid_s[10];
+    char remote_domid_s[16];
 
     signal(SIGCHLD, sigchld_handler);
     signal(SIGUSR1, sigusr1_handler);
     snprintf(pid_s, sizeof(pid_s), "%d", getpid());
     setenv("QREXEC_AGENT_PID", pid_s, 1);
+    snprintf(remote_domid_s, sizeof(remote_domid_s), "%d", remote_domid);
+    setenv("QREXEC_REMOTE_DOMAIN_ID", remote_domid_s, 1);
 }
 
 int handle_handshake(libvchan_t *ctrl)
@@ -511,7 +514,7 @@ int handle_new_process_common(int type, int connect_domain, int connect_port,
     }
     handle_handshake(data_vchan);
 
-    prepare_child_env();
+    prepare_child_env(connect_domain);
     /* TODO: use setresuid to allow child process to actually send the signal? */
 
     switch (type) {

--- a/qrexec/qrexec-agent-data.c
+++ b/qrexec/qrexec-agent-data.c
@@ -57,7 +57,7 @@ static void sigusr1_handler(int __attribute__((__unused__))x)
     signal(SIGUSR1, SIG_IGN);
 }
 
-void prepare_child_env(int remote_domid) {
+void prepare_child_env(int remote_domid, char *remote_dom) {
     char pid_s[10];
     char remote_domid_s[16];
 
@@ -67,6 +67,8 @@ void prepare_child_env(int remote_domid) {
     setenv("QREXEC_AGENT_PID", pid_s, 1);
     snprintf(remote_domid_s, sizeof(remote_domid_s), "%d", remote_domid);
     setenv("QREXEC_REMOTE_DOMAIN_ID", remote_domid_s, 1);
+    if (remote_dom) /* otherwise, multiplexer handles this later */
+        setenv("QREXEC_REMOTE_DOMAIN", remote_dom, 1);
 }
 
 int handle_handshake(libvchan_t *ctrl)
@@ -514,7 +516,7 @@ int handle_new_process_common(int type, int connect_domain, int connect_port,
     }
     handle_handshake(data_vchan);
 
-    prepare_child_env(connect_domain);
+    prepare_child_env(connect_domain, NULL);
     /* TODO: use setresuid to allow child process to actually send the signal? */
 
     switch (type) {

--- a/qrexec/qrexec-agent.h
+++ b/qrexec/qrexec-agent.h
@@ -25,7 +25,7 @@ int handle_handshake(libvchan_t *ctrl);
 void handle_vchan_error(const char *op);
 void do_exec(const char *cmd);
 /* call before fork() for service handling process (either end) */
-void prepare_child_env(int remote_domid);
+void prepare_child_env(int remote_domid, char *remote_dom);
 
 pid_t handle_new_process(int type,
         int connect_domain, int connect_port,

--- a/qrexec/qrexec-agent.h
+++ b/qrexec/qrexec-agent.h
@@ -25,7 +25,7 @@ int handle_handshake(libvchan_t *ctrl);
 void handle_vchan_error(const char *op);
 void do_exec(const char *cmd);
 /* call before fork() for service handling process (either end) */
-void prepare_child_env();
+void prepare_child_env(int remote_domid);
 
 pid_t handle_new_process(int type,
         int connect_domain, int connect_port,

--- a/qrexec/qrexec-client-vm.c
+++ b/qrexec/qrexec-client-vm.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
             perror("socketpair");
             exit(1);
         }
-        prepare_child_env(exec_params.connect_domain);
+        prepare_child_env(exec_params.connect_domain, params.target_domain);
 
         switch (child_pid = fork()) {
             case -1:

--- a/qrexec/qrexec-client-vm.c
+++ b/qrexec/qrexec-client-vm.c
@@ -122,7 +122,7 @@ int main(int argc, char **argv)
             perror("socketpair");
             exit(1);
         }
-        prepare_child_env();
+        prepare_child_env(exec_params.connect_domain);
 
         switch (child_pid = fork()) {
             case -1:


### PR DESCRIPTION
Surface the numerical Xen domid of the qrexec connection's remote VM to the local program as `$QREXEC_REMOTE_DOMAIN_ID`.

Use case: This variable makes it surprisingly easy to get client VMs to communicate with sys-whonix via Socks-over-qrexec, while preserving Tor circuit isolation between the different client VMs:

    #!/bin/sh
    #
    # /etc/qubes-rpc/SocksAdapter in sys-whonix

    n=$QREXEC_REMOTE_DOMAIN_ID
    src_ip=127.137.$((n / 256)).$((n % 256))

    exec socat STDIN TCP4:127.0.0.1:9150,bind=$src_ip

(The client VM would run the opposite adapter, using `socat` or a systemd socket unit to redirect Socks requests from e.g. the browser to `qrexec-client sys-whonix SocksAdapter`.)