### PR TITLE
Shut down after update only if it's a template.

### DIFF
--- a/qubes-rpc/qubes.InstallUpdatesGUI
+++ b/qubes-rpc/qubes.InstallUpdatesGUI
@@ -17,7 +17,7 @@ elif [ -e /etc/arch-release ]; then
 else
     update_cmd='echo Unsupported distribution, install updates manually; bash -i'
 fi
-xterm -title update -e su -l -c "$update_cmd; echo Done.; echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff;"
+xterm -title update -e su -l -c "$update_cmd; echo Done.; test -f /var/run/qubes/this-is-templatevm && { echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff; } ;"
 
 # Notify dom0 about installed updates
 su -c 'service qubes-update-check start'


### PR DESCRIPTION
As per discussion in
https://github.com/QubesOS/qubes-issues/issues/2555#issuecomment-271415169

Note: I've kept the semicolon at the end of the command, but I'm not sure why it was there in the first place. Tested on Debian Standalone VM and Template.