### PR TITLE
Add archlinux support to upgrade checker

### DIFF
--- a/misc/upgrades-installed-check
+++ b/misc/upgrades-installed-check
@@ -21,6 +21,13 @@ elif [ -e /etc/debian_version ]; then
    apt_get_upgrade_output="$(LANG="C" apt-get -s upgrade 2>&1)"
    exit_code="$?"
    echo "$apt_get_upgrade_output" | awk "/^Inst/{ print $2 }" | [ "$(wc -L)" -eq 0 ] && echo "true" || echo "false"
+elif [ -e /etc/arch-release ]; then
+    ## Archlinux
+    set -e
+    set -o pipefail
+    checkupdates_output="$(checkupdates 2>&1)"
+    exit_code="$?"
+    echo "$checkupdates_output" | grep '->' | [ "$(wc -L)" -eq 0 ] && echo "true" || echo "false"
 else
    echo "Check not implemented for this distribution" >&2
    exit 1


### PR DESCRIPTION
This commit adds Archlinux support to the upgrade checker utility, via `checkupdates`, which is part of the `pacman` package:

```
$ pacman -Qo `which checkupdates`
/usr/bin/checkupdates is owned by pacman 5.0.1-4
```