### PR TITLE
Apply gschema override preventing previews in nautilus in Debian

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,8 @@ install-deb: install-common install-systemd install-systemd-dropins
 	install -m 0644 misc/pam.d_su.qubes $(DESTDIR)/etc/pam.d/su.qubes
 	install -d $(DESTDIR)/etc/needrestart/conf.d
 	install -D -m 0644 misc/50_qubes.conf $(DESTDIR)/etc/needrestart/conf.d/50_qubes.conf
+	install -d $(DESTDIR)/usr/share/glib-2.0/schemas/
+	install -m 0644 misc/org.gnome.nautilus.gschema.override $(DESTDIR)/usr/share/glib-2.0/schemas/
 
 
 install-vm: install-rh install-common

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -141,6 +141,9 @@ case "${1}" in
             dpkg-statoverride --update --add user user 775 /var/lib/qubes/dom0-updates
         fi
 
+        /usr/bin/glib-compile-schemas /usr/share/glib-2.0/schemas
+
+
         # Update Qubes App Menus
         /usr/lib/qubes/qubes-trigger-sync-appmenus.sh || true
         ;;


### PR DESCRIPTION
QubesOS/qubes-issues#1108
The prevention of previews is already set in Fedora packages.
This applies it to Debian packages too.
