### PR TITLE
network: Properly handle comments in NetworkManager.conf (#2584)

### DIFF
--- a/network/network-manager-prepare-conf-dir
+++ b/network/network-manager-prepare-conf-dir
@@ -13,7 +13,7 @@ unmanaged_devices=mac:fe:ff:ff:ff:ff:ff
 #for mac in `xenstore-ls device/vif | grep mac | cut -d= -f2 | tr -d '" '`; do
 #    unmanaged_devices="$unmanaged_devices;mac:$mac"
 #done
-sed -i -e "s/^unmanaged-devices=.*/unmanaged-devices=$unmanaged_devices/" /etc/NetworkManager/NetworkManager.conf
-sed -i -e "s/^plugins=.*/plugins=keyfile/" /etc/NetworkManager/NetworkManager.conf
+sed -r -i -e "s/^#?unmanaged-devices=.*/unmanaged-devices=$unmanaged_devices/" /etc/NetworkManager/NetworkManager.conf
+sed -r -i -e "s/^#?plugins=.*/plugins=keyfile/" /etc/NetworkManager/NetworkManager.conf
 
 exit 0


### PR DESCRIPTION
Qubes-specific options must be added in NetworkManager.conf, even if
those lines are commented out by default. The problem is solved by using
extended regular expressions.

Fixes #2584