### PR TITLE
dom0-updates: do not modify yum.conf

### DIFF
--- a/misc/qubes-download-dom0-updates.sh
+++ b/misc/qubes-download-dom0-updates.sh
@@ -61,7 +61,6 @@ if ! [ -d "$DOM0_UPDATES_DIR" ]; then
 fi
 
 mkdir -p $DOM0_UPDATES_DIR/etc
-sed -i '/^reposdir\s*=/d' $DOM0_UPDATES_DIR/etc/yum.conf
 
 if [ -e /etc/debian_version ]; then
     # Default rpm configuration on Debian uses ~/.rpmdb for rpm database (as


### PR DESCRIPTION
Few reasons for this:
1. new templates use dnf to download packages, so yum.conf is unused
2. dom0 in Qubes 4.0 don't have this file at all (so sed fails here)
3. $OPTS already contains --setopt=reposdir=...

Fixes QubesOS/qubes-issues#2945