### PR TITLE
archlinux: add correct section to qubes-noupgrade.conf

### DIFF
--- a/archlinux/PKGBUILD-qubes-noupgrade.conf
+++ b/archlinux/PKGBUILD-qubes-noupgrade.conf
@@ -1,2 +1,3 @@
+[options]
 NoUpgrade = etc/pam.d/su
 NoUpgrade = etc/pam.d/su-l


### PR DESCRIPTION
Some pacman wrappers like powerpill will fail to parse the config file when the options are not sectioned correctly:

```
pycman.config.InvalidSyntax: unable to parse /etc/pacman.d/10-qubes-noupgrade.conf, invalid key for repository configuration: 'NoUpgrade = etc/pam.d/su'
```