### PR TITLE
Archlinux template fixes for QubesOS 4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,11 @@ install-common: install-doc
 	# force /usr/bin before /bin to have /usr/bin/python instead of /bin/python
 	PATH="/usr/bin:$(PATH)" python setup.py install $(PYTHON_PREFIX_ARG) -O1 --root $(DESTDIR)
 	mkdir -p $(DESTDIR)$(SBINDIR)
+
+ifneq ($(SBINDIR),/usr/bin)
 	mv $(DESTDIR)/usr/bin/qubes-firewall $(DESTDIR)$(SBINDIR)/qubes-firewall
+endif
+
 
 	install -d -m 0750 $(DESTDIR)/etc/sudoers.d/
 	install -D -m 0440 misc/qubes.sudoers $(DESTDIR)/etc/sudoers.d/qubes

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -25,8 +25,8 @@ changelog=
 source=(
     PKGBUILD.qubes-ensure-lib-modules.service PKGBUILD.qubes-update-desktop-icons.hook
     PKGBUILD-qubes-noupgrade.conf
-    PKGBUILD-qubes-repo-3.1.conf
     PKGBUILD-qubes-repo-3.2.conf
+    PKGBUILD-qubes-repo-4.0.conf
 )
 
 noextract=()

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -85,9 +85,9 @@ package() {
     install -m 644 "$srcdir/PKGBUILD-qubes-noupgrade.conf" "${pkgdir}/etc/pacman.d/10-qubes-noupgrade.conf"
 
     # Install pacman repository
-    #release=$(echo "$pkgver" | cut -d '.' -f 1,2)
-    #echo "Installing repository for release ${release}"
-    #install -m 644 "$srcdir/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
+    release=$(echo "$pkgver" | cut -d '.' -f 1,2)
+    echo "Installing repository for release ${release}"
+    install -m 644 "$srcdir/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
 
     # Archlinux specific: enable autologin on tty1
     mkdir -p "$pkgdir/etc/systemd/system/getty@tty1.service.d/"

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -11,7 +11,7 @@ url="http://qubes-os.org/"
 license=('GPL')
 groups=()
 depends=("qubes-vm-utils>=3.1.3" python2 python3 python2-xdg ethtool ntp net-tools gnome-packagekit imagemagick fakeroot notification-daemon dconf zenity qubes-libvchan "qubes-db-vm>=3.2.1" haveged python2-gobject python2-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg)
-makedepends=(gcc make pkg-config "qubes-vm-utils>=3.1.3" qubes-libvchan qubes-db-vm qubes-vm-xen libx11 python2 python3 lsb-release)
+makedepends=(gcc make pkg-config "qubes-vm-utils>=3.1.3" qubes-libvchan qubes-db-vm qubes-vm-xen libx11 python2 python3 lsb-release pandoc)
 checkdepends=()
 optdepends=(gnome-keyring gnome-settings-daemon networkmanager iptables tinyproxy python2-nautilus gpk-update-viewer)
 provides=()
@@ -33,7 +33,7 @@ noextract=()
 md5sums=(SKIP)
 
 build() {
-    for source in autostart-dropins qubes-rpc qrexec misc Makefile vm-init.d vm-systemd network init version; do
+    for source in autostart-dropins qubes-rpc qrexec misc Makefile vm-init.d vm-systemd network init version doc setup.py qubesagent post-install.d; do
         # shellcheck disable=SC2154
         (ln -s "$srcdir/../$source" "$srcdir/$source")
     done
@@ -85,9 +85,9 @@ package() {
     install -m 644 "$srcdir/PKGBUILD-qubes-noupgrade.conf" "${pkgdir}/etc/pacman.d/10-qubes-noupgrade.conf"
 
     # Install pacman repository
-    release=$(echo "$pkgver" | cut -d '.' -f 1,2)
-    echo "Installing repository for release ${release}"
-    install -m 644 "$srcdir/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
+    #release=$(echo "$pkgver" | cut -d '.' -f 1,2)
+    #echo "Installing repository for release ${release}"
+    #install -m 644 "$srcdir/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
 
     # Archlinux specific: enable autologin on tty1
     mkdir -p "$pkgdir/etc/systemd/system/getty@tty1.service.d/"

--- a/archlinux/PKGBUILD-qubes-repo-4.0.conf
+++ b/archlinux/PKGBUILD-qubes-repo-4.0.conf
@@ -1,2 +1,2 @@
-[qubes-r3.1]
+[qubes-r4.0]
 Server = http://olivier.medoc.free.fr/archlinux/current


### PR DESCRIPTION
This fixes the archlinux `core-agent-linux` build for QubesOS 4.0. The binary pacman repo is completely disabled because as far as I know @ptitdoc builds only 3.2 packages there.

Parent issue: QubesOS/qubes-issues#3185