### PR TITLE
Handle resize of root filesystem with new partition layout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,6 +201,7 @@ install-common: install-doc
 		$(DESTDIR)/usr/share/glib-2.0/schemas/
 	install -g user -m 2775 -d $(DESTDIR)/var/lib/qubes/dom0-updates
 	install -D -m 0644 misc/qubes-master-key.asc $(DESTDIR)/usr/share/qubes/qubes-master-key.asc
+	install misc/resize-rootfs $(DESTDIR)$(LIBDIR)/qubes/
 
 	install misc/close-window $(DESTDIR)$(LIBDIR)/qubes/close-window
 

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -70,6 +70,7 @@ lib/systemd/system/org.cups.cupsd.socket.d/30_qubes.conf
 lib/systemd/system/qubes-early-vm-config.service
 lib/systemd/system/qubes-misc-post.service
 lib/systemd/system/qubes-mount-dirs.service
+lib/systemd/system/qubes-rootfs-resize.service
 lib/systemd/system/qubes-sysinit.service
 lib/systemd/system/qubes-update-check.service
 lib/systemd/system/qubes-update-check.timer
@@ -110,6 +111,7 @@ usr/lib/qubes/init/mount-dirs.sh
 usr/lib/qubes/init/qubes-early-vm-config.sh
 usr/lib/qubes/init/qubes-random-seed.sh
 usr/lib/qubes/init/qubes-sysinit.sh
+usr/lib/qubes/init/resize-rootfs-if-needed.sh
 usr/lib/qubes/init/setup-rw.sh
 usr/lib/qubes/init/setup-rwdev.sh
 usr/lib/qubes/prepare-suspend

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -123,6 +123,7 @@ usr/lib/qubes/qvm-copy-to-vm.gnome
 usr/lib/qubes/qvm-copy-to-vm.kde
 usr/lib/qubes/qvm-move-to-vm.gnome
 usr/lib/qubes/qvm-move-to-vm.kde
+usr/lib/qubes/resize-rootfs
 usr/lib/qubes/tar2qfile
 usr/lib/qubes/update-proxy-configs
 usr/lib/qubes/upgrades-installed-check

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Possibly resize root device (partition, filesystem), if underlying device was
+# enlarged.
+
+set -e
+
+# if underlying root device is read-only, don't do anything
+if [ "$(blockdev --getro /dev/xvda)" -eq "1" ]; then
+    echo "xvda is read-only, not resizing" >&2
+    exit 0
+fi
+
+sysfs_root_dev="/sys/dev/block/$(mountpoint -d /)"
+sysfs_xvda="/sys/class/block/xvda"
+
+# if root filesystem use already (almost) the whole dis
+non_rootfs_data=$(( 250 * 1024 * 2 ))
+if [ "$(cat "$sysfs_xvda/size")" -lt \
+       $(( non_rootfs_data + $(cat "$sysfs_root_dev/size") )) ]; then
+   echo "root filesystem already at the right size" >&2
+   exit 0
+fi
+
+# resize needed, do it
+/usr/lib/qubes/resize-rootfs

--- a/misc/resize-rootfs
+++ b/misc/resize-rootfs
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -e
+
+dm_major=$(printf %x "$(grep device-mapper /proc/devices | cut -f 1 -d ' ')")
+case "$(stat -Lc %t:%T /dev/mapper/dmroot)" in
+    ca:0)
+        # nothing needed, xvda used directly
+        ;;
+    ca:3)
+        # resize partition table itself
+        # use undocumented ---pretend-input-tty (yes, three '-') to
+        # force unattended operation, otherwise it aborts on first
+        # prompt, even with '-s' option
+        echo fix | parted ---pretend-input-tty /dev/xvda print >/dev/null
+        # then resize 3rd partition, even though it is mounted
+        echo yes 100% | parted ---pretend-input-tty /dev/xvda resizepart 3
+        # and reload partition table; prefer partprobe over blockdev
+        # --rereadpt, as it works on mounted partitions
+        partprobe /dev/xvda
+        ;;
+    ca:*)
+        echo "Unsupported partition layout, resize it manually" >&2
+        exit 1
+        ;;
+    $dm_major:*)
+        new_size=$(cat /sys/block/xvda/size)
+        ro=$(cat /sys/block/xvda/ro)
+        if [ "$ro" -eq 1 ]; then
+            new_table="0 $new_size snapshot /dev/xvda /dev/xvdc2 N 16"
+        else
+            new_table="0 $new_size linear /dev/xvda 0"
+        fi
+        dmsetup load dmroot --table "$new_table"
+        dmsetup resume dmroot
+        ;;
+    *)
+        echo "Unsupported device type for root volume, resize it manually" >&2
+        exit 1
+        ;;
+esac
+resize2fs /dev/mapper/dmroot

--- a/qubes-rpc/qubes.ResizeDisk
+++ b/qubes-rpc/qubes.ResizeDisk
@@ -13,22 +13,10 @@ case $disk_name in
     root)
         # force some read to refresh device size
         head /dev/xvda > /dev/null
-        if [ "$(stat -Lc %t /dev/mapper/dmroot)" != "ca" ]; then
-            new_size=$(cat /sys/block/xvda/size)
-            ro=$(/sys/block/xvda/ro)
-            if [ "$ro" -eq 1 ]; then
-                new_table="0 $new_size snapshot /dev/xvda /dev/xvdc2 N 16"
-            else
-                new_table="0 $new_size linear /dev/xvda 0"
-            fi
-            dmsetup load dmroot --table "$new_table"
-            dmsetup resume dmroot
-        fi
-        resize2fs /dev/mapper/dmroot
+        /usr/lib/qubes/resize-rootfs
         ;;
     *)
         echo "Automatic resize of '$disk_name' not supported" >&2
         exit 1
         ;;
 esac
-        

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -617,6 +617,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/init/qubes-early-vm-config.sh
 /usr/lib/qubes/init/qubes-random-seed.sh
 /usr/lib/qubes/init/qubes-sysinit.sh
+/usr/lib/qubes/init/resize-rootfs-if-needed.sh
 /usr/lib/qubes/init/setup-rw.sh
 /usr/lib/qubes/init/setup-rwdev.sh
 /usr/lib/qubes/init/functions
@@ -804,6 +805,7 @@ The Qubes core startup configuration for SystemD init.
 %defattr(-,root,root,-)
 /lib/systemd/system/qubes-misc-post.service
 /lib/systemd/system/qubes-mount-dirs.service
+/lib/systemd/system/qubes-rootfs-resize.service
 /lib/systemd/system/qubes-sysinit.service
 /lib/systemd/system/qubes-early-vm-config.service
 /lib/systemd/system/qubes-update-check.service

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -604,6 +604,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/upgrades-installed-check
 /usr/lib/qubes/upgrades-status-notify
 /usr/lib/qubes/qubes-sync-clock
+/usr/lib/qubes/resize-rootfs
 /usr/lib/yum-plugins/yum-qubes-hooks.py*
 /usr/lib/dracut/dracut.conf.d/30-qubes.conf
 %dir /usr/lib/qubes/init

--- a/vm-init.d/qubes-core-early
+++ b/vm-init.d/qubes-core-early
@@ -15,6 +15,11 @@ start()
 {
 	have_qubesdb || return
 
+	echo -n $"Adjusting root filesystem size:"
+	# shellcheck disable=SC2015
+	/usr/lib/qubes/init/resize-rootfs-if-needed.sh && success || failure
+	echo
+
 	echo -n $"Setting up Qubes persistent file systems:"
     # shellcheck disable=SC2015
 	/usr/lib/qubes/init/mount-dirs.sh && success || failure

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -85,6 +85,7 @@ enable qubes-updates-proxy.service
 enable qubes-network.service
 enable qubes-qrexec-agent.service
 enable qubes-mount-dirs.service
+enable qubes-rootfs-resize.service
 enable qubes-firewall.service
 enable qubes-meminfo-writer.service
 enable qubes-iptables.service

--- a/vm-systemd/qubes-rootfs-resize.service
+++ b/vm-systemd/qubes-rootfs-resize.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Adjust root filesystem size
+# There is a dependency on dev-xvdb.device because
+# mount-dirs.sh calls setup-rwdev.sh which
+# must happen only when /dev/xvdb has appeared.
+After=qubes-sysinit.service dev-xvda.device
+DefaultDependencies=no
+Before=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/qubes/init/resize-rootfs-if-needed.sh
+# There is no need for an ExecStop because systemd
+# cleans up mount units in the right order, killing
+# processes as needed.
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Implement resizing of root filesystem when it is the last partition.

This handle both online (qubes.ResizeDisk service) method and offline (resize
on domain startup).

Fixes QubesOS/qubes-issues#3173
QubesOS/qubes-issues#3143