### PR TITLE
Disable dnf plugins when downloading dom0 updates in sys-firewall

### DIFF
--- a/misc/qubes-download-dom0-updates.sh
+++ b/misc/qubes-download-dom0-updates.sh
@@ -52,7 +52,7 @@ fi
 
 YUM="yum"
 if type dnf >/dev/null 2>&1; then
-    YUM="dnf --best --allowerasing"
+    YUM="dnf --best --allowerasing --noplugins"
 fi
 
 if ! [ -d "$DOM0_UPDATES_DIR" ]; then


### PR DESCRIPTION
Since the qubes-download-dom0-updates script executes dnf with fakeroot, some dnf plugins like etckeeper break the update with "Permission denied" errors.