### PR TITLE
Makefile split of core-agent and networking tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -384,7 +384,7 @@ install-deb: install-common install-systemd install-systemd-dropins install-syst
 	mkdir -p $(DESTDIR)/etc/systemd/system/
 	install -m 0644 vm-systemd/haveged.service  $(DESTDIR)/etc/systemd/system/
 
-install-corevm: install-rh install-common install-systemd install-sysvinit install-systemd-dropins
+install-corevm: install-rh install-common install-systemd install-sysvinit install-systemd-dropins install-networking
 
 install-netvm: install-systemd-networking-dropins install-networkmanager install-netvm
 

--- a/Makefile
+++ b/Makefile
@@ -384,4 +384,8 @@ install-deb: install-common install-systemd install-systemd-dropins install-syst
 	mkdir -p $(DESTDIR)/etc/systemd/system/
 	install -m 0644 vm-systemd/haveged.service  $(DESTDIR)/etc/systemd/system/
 
-install-vm: install-rh install-common
+install-corevm: install-rh install-common install-systemd install-sysvinit install-systemd-dropins
+
+install-netvm: install-systemd-networking-dropins install-networkmanager install-netvm
+
+install-vm: install-corevm install-netvm

--- a/Makefile
+++ b/Makefile
@@ -359,7 +359,7 @@ install-networkmanager:
 	install network/{qubes-nmhook,30-qubes-external-ip} $(DESTDIR)/etc/NetworkManager/dispatcher.d/
 
 	install -d $(DESTDIR)/usr/lib/NetworkManager/conf.d
-	install -m 0644 network/nm-30-qubes.conf $(DESTDIR)/usr/lib/NetworkManager/conf.d/30
+	install -m 0644 network/nm-30-qubes.conf $(DESTDIR)/usr/lib/NetworkManager/conf.d/30-qubes.conf
 
 	install -d $(DESTDIR)/etc/xdg/autostart
 	install -m 0755 network/show-hide-nm-applet.sh $(DESTDIR)$(LIBDIR)/qubes/

--- a/Makefile
+++ b/Makefile
@@ -365,7 +365,7 @@ install-networkmanager:
 	install -m 0755 network/show-hide-nm-applet.sh $(DESTDIR)$(LIBDIR)/qubes/
 	install -m 0644 network/show-hide-nm-applet.desktop $(DESTDIR)/etc/xdg/autostart/00-qubes-show-hide-nm-applet.desktop
 
-install-deb: install-common install-systemd install-systemd-dropins install-systemd-networking-dropins
+install-deb: install-common install-systemd install-systemd-dropins install-systemd-networking-dropins install-networking install-networkmanager install-netvm
 	mkdir -p $(DESTDIR)/etc/apt/sources.list.d
 	sed -e "s/@DIST@/`lsb_release -cs`/" misc/qubes-r4.list.in > $(DESTDIR)/etc/apt/sources.list.d/qubes-r4.list
 	install -D -m 644 misc/qubes-archive-keyring.gpg $(DESTDIR)/etc/apt/trusted.gpg.d/qubes-archive-keyring.gpg

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Maintainer: Olivier Medoc <o_medoc@yahoo.fr>
 # shellcheck disable=SC2034
-pkgname=qubes-vm-core
+pkgname=(qubes-vm-core qubes-vm-networking)
 pkgver=$(cat version)
 pkgrel=13
 epoch=
@@ -10,16 +10,13 @@ arch=("x86_64")
 url="http://qubes-os.org/"
 license=('GPL')
 groups=()
-depends=("qubes-vm-utils>=3.1.3" python2 python2-xdg ethtool ntp net-tools gnome-packagekit imagemagick fakeroot notification-daemon dconf zenity qubes-libvchan "qubes-db-vm>=3.2.1" haveged python2-gobject python2-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg)
 makedepends=(gcc make pkg-config "qubes-vm-utils>=3.1.3" qubes-libvchan qubes-db-vm qubes-vm-xen libx11 python2 python3 lsb-release pandoc)
 checkdepends=()
-optdepends=(gnome-keyring gnome-settings-daemon networkmanager iptables tinyproxy python2-nautilus gpk-update-viewer)
 provides=()
 conflicts=()
 replaces=()
 backup=()
 options=()
-install=PKGBUILD.install
 changelog=
 
 source=(
@@ -60,15 +57,25 @@ build() {
     done
 }
 
-package() {
+package_qubes-vm-core() {
+    depends=("qubes-vm-utils>=3.1.3" python2 python2-xdg ethtool ntp net-tools
+             gnome-packagekit imagemagick fakeroot notification-daemon dconf
+             zenity qubes-libvchan "qubes-db-vm>=3.2.1" haveged python2-gobject
+             python2-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg
+             socat
+             )
+    optdepends=(gnome-keyring gnome-settings-daemon python2-nautilus gpk-update-viewer)
+    install=PKGBUILD.install
+
     # Note: Archlinux removed use of directory such as /sbin /bin /usr/sbin (https://mailman.archlinux.org/pipermail/arch-dev-public/2012-March/022625.html)
     # shellcheck disable=SC2154
     make -C qrexec install DESTDIR="$pkgdir" SBINDIR=/usr/bin LIBDIR=/usr/lib SYSLIBDIR=/usr/lib
 
-    PYTHON=python2 make install-vm DESTDIR="$pkgdir" SBINDIR=/usr/bin LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SYSTEM_DROPIN_DIR=/usr/lib/systemd/system USER_DROPIN_DIR=/usr/lib/systemd/user DIST=archlinux
+    PYTHON=python2 make install-corevm DESTDIR="$pkgdir" SBINDIR=/usr/bin LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SYSTEM_DROPIN_DIR=/usr/lib/systemd/system USER_DROPIN_DIR=/usr/lib/systemd/user DIST=archlinux
 
     # Remove things non wanted in archlinux
     rm -r "$pkgdir/etc/yum"*
+    rm -r "$pkgdir/etc/dnf"*
     rm -r "$pkgdir/etc/init.d"
     # Remove fedora specific scripts
     rm "$pkgdir/etc/fstab"
@@ -99,6 +106,27 @@ EOF
 
     # Archlinux packaging guidelines: /var/run is a symlink to a tmpfs. Don't create it
     rm -r "$pkgdir/var/run"
+}
+
+#This package provides:
+# * basic network functionality (setting IP address, DNS, default gateway)
+# * proxy service used by TemplateVMs to download updates
+# * qubes-firewall service (FirewallVM)
+#
+#Integration of NetworkManager for Qubes VM:
+# * make connections config persistent
+# * adjust DNS redirections when needed
+# * show/hide NetworkManager applet icon
+#
+package_qubes-vm-networking() {
+    depends=(qubes-vm-core "qubes-vm-utils>=3.1.3" python2 ethtool net-tools
+             "qubes-db-vm>=3.2.1" networkmanager iptables tinyproxy nftables
+             )
+    install=PKGBUILD-networking.install
+
+    # shellcheck disable=SC2154
+    PYTHON=python2 make install-netvm DESTDIR="$pkgdir" SBINDIR=/usr/bin LIBDIR=/usr/lib SYSLIBDIR=/usr/lib SYSTEM_DROPIN_DIR=/usr/lib/systemd/system USER_DROPIN_DIR=/usr/lib/systemd/user DIST=archlinux
+
 }
 
 # vim:set ts=2 sw=2 et:

--- a/archlinux/PKGBUILD-networking.install
+++ b/archlinux/PKGBUILD-networking.install
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+## arg 1:  the new package version
+post_install() {
+    # Create NetworkManager configuration if we do not have it
+    if ! [ -e /etc/NetworkManager/NetworkManager.conf ]; then
+    echo '[main]' > /etc/NetworkManager/NetworkManager.conf
+    echo 'plugins = keyfile' >> /etc/NetworkManager/NetworkManager.conf
+    echo '[keyfile]' >> /etc/NetworkManager/NetworkManager.conf
+    fi
+
+    # Remove ip_forward setting from sysctl, so NM will not reset it
+    # Archlinux now use sysctl.d/ instead of sysctl.conf
+    #sed 's/^net.ipv4.ip_forward.*/#\0/'  -i /etc/sysctl.conf
+
+    /usr/lib/qubes/qubes-fix-nm-conf.sh
+
+    # Yum proxy configuration is fedora specific
+    #if ! grep -q '/etc/yum\.conf\.d/qubes-proxy\.conf' /etc/yum.conf; then
+    #  echo >> /etc/yum.conf
+    #  echo '# Yum does not support inclusion of config dir...' >> /etc/yum.conf
+    #  echo 'include=file:///etc/yum.conf.d/qubes-proxy.conf' >> /etc/yum.conf
+    #fi
+
+    for srv in qubes-firewall.service qubes-iptables.service qubes-network.service qubes-updates-proxy.service ; do
+        systemctl enable $srv.service
+    done
+}
+
+## arg 1:  the new package version
+## arg 2:  the old package version
+post_upgrade() {
+    post_install
+}
+
+## arg 1:  the old package version
+post_remove() {
+    for srv in qubes-firewall.service qubes-iptables.service qubes-network.service qubes-updates-proxy.service ; do
+        systemctl disable $srv.service
+    done
+}

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -74,29 +74,11 @@ configure_selinux() {
 ############################
 
 update_qubesconfig() {
-    # Create NetworkManager configuration if we do not have it
-    if ! [ -e /etc/NetworkManager/NetworkManager.conf ]; then
-    echo '[main]' > /etc/NetworkManager/NetworkManager.conf
-    echo 'plugins = keyfile' >> /etc/NetworkManager/NetworkManager.conf
-    echo '[keyfile]' >> /etc/NetworkManager/NetworkManager.conf
-    fi
-    /usr/lib/qubes/qubes-fix-nm-conf.sh
-
-    # Remove ip_forward setting from sysctl, so NM will not reset it
-    # Archlinux now use sysctl.d/ instead of sysctl.conf
-    #sed 's/^net.ipv4.ip_forward.*/#\0/'  -i /etc/sysctl.conf
-
     # Remove old firmware updates link
     if [ -L /lib/firmware/updates ]; then
       rm -f /lib/firmware/updates
     fi
 
-    # Yum proxy configuration is fedora specific
-    #if ! grep -q '/etc/yum\.conf\.d/qubes-proxy\.conf' /etc/yum.conf; then
-    #  echo >> /etc/yum.conf
-    #  echo '# Yum does not support inclusion of config dir...' >> /etc/yum.conf
-    #  echo 'include=file:///etc/yum.conf.d/qubes-proxy.conf' >> /etc/yum.conf
-    #fi
     #/usr/lib/qubes/update-proxy-configs
     # Archlinux pacman configuration is handled in update_finalize
 
@@ -438,7 +420,7 @@ post_remove() {
 
     rm -rf /var/lib/qubes/xdg
 
-    for srv in qubes-sysinit qubes-misc-post qubes-mount-dirs qubes-network qubes-qrexec-agent; do
+    for srv in qubes-sysinit qubes-misc-post qubes-mount-dirs qubes-qrexec-agent; do
         systemctl disable $srv.service
     done
 }


### PR DESCRIPTION
Split install targets of the Makefile to add:
install-network: basic networking for VM
install-networkmanager: qubes network manager files
install-netvm: files required for a working netvm (include firewall stuff, dns ...

The main goal is to use it to generate different packages in archlinux, which requires files to be explicitly installed.

The Makefile could be splitted in more target as it could be used as documentation (role of the different files).