### PR TITLE
Fix the Archlinux template update proxy to work for HTTPS URLs as well

### DIFF
--- a/network/update-proxy-configs
+++ b/network/update-proxy-configs
@@ -122,7 +122,7 @@ if [ -d /etc/pacman.d ]; then
 ### If you want to override some of this settings, create another file under 
 ### /etc/pacman.d
 [options]
-XferCommand = http_proxy=$PROXY_ADDR /usr/bin/curl -C - -f %u > %o
+XferCommand = ALL_PROXY=$PROXY_ADDR /usr/bin/curl -C - -f %u > %o
 EOF
     else
         rm -r /etc/pacman.d/01-qubes-proxy.conf


### PR DESCRIPTION
I was getting more errors than expected when updating the template and it was because I'd used an HTTPS pacman repository. [This](https://curl.haxx.se/docs/manpage.html#ENVIRONMENT) is the curl documentation on proxy configuration. I tested the change with my template and it worked.