### PR TITLE
Fix Ubuntu template builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,6 +302,8 @@ endif
 
 ifeq ($(shell lsb_release -is), Debian)
 	install -m 0644 misc/qubesxdg.py $(DESTDIR)/$(PYTHON2_SITELIB)/
+else ifeq ($(shell lsb_release -is), Ubuntu)
+	install -m 0644 misc/qubesxdg.py $(DESTDIR)/$(PYTHON2_SITELIB)/
 else
 	install -m 0644 misc/py2/qubesxdg.py* $(DESTDIR)/$(PYTHON2_SITELIB)/
 endif

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -12,6 +12,11 @@ endif
 source-debian-quilt-copy-in: VERSION = $(shell cat $(ORIG_SRC)/version)
 source-debian-quilt-copy-in: ORIG_FILE = "$(CHROOT_DIR)/$(DIST_SRC)/../qubes-core-agent_$(VERSION).orig.tar.gz"
 source-debian-quilt-copy-in:
+	if [ $(DISTRIBUTION) == qubuntu ] ; then \
+		sed -i /avahi-daemon.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
+		sed -i /exim4.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
+		sed -i /netfilter-persistent.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
+	fi
 	if [ $(DIST) == trusty ] ; then \
 		sed -i /locales-all/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
 	fi


### PR DESCRIPTION
4.0 template builds use `<package>.install` files with dh_install.  The
differences between Debian and Ubuntu packages also need to be represented
in these files.