### PR TITLE
Add iptables dep to qubes-core-agent-networking RPM spec

### DIFF
--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -228,6 +228,7 @@ Scripts required to handle dom0 updates.
 %package networking
 Summary:    Networking support for Qubes VM
 Requires:   ethtool
+Requires:   iptables
 Requires:   net-tools
 Requires:   nftables
 Requires:   socat


### PR DESCRIPTION
For R4.0, where `iptables[-restore]` is still used by `vif-route-qubes`, `qubes-setup-dnat-to-ns`, and `iptables-updates-proxy`.