### PR TITLE
VM side of IPv6 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -345,6 +345,7 @@ endif
 
 	install -m 0400 -D network/iptables $(DESTDIR)/etc/qubes/iptables.rules
 	install -m 0400 -D network/ip6tables $(DESTDIR)/etc/qubes/ip6tables.rules
+	install -m 0400 -D network/ip6tables-enabled $(DESTDIR)/etc/qubes/ip6tables-enabled.rules
 
 	install -m 0755 -D qubes-rpc/qubes.UpdatesProxy $(DESTDIR)/etc/qubes-rpc/qubes.UpdatesProxy
 

--- a/debian/qubes-core-agent-networking.install
+++ b/debian/qubes-core-agent-networking.install
@@ -1,6 +1,7 @@
 etc/dhclient.d/qubes-setup-dnat-to-ns.sh
 etc/qubes-rpc/qubes.UpdatesProxy
 etc/qubes/ip6tables.rules
+etc/qubes/ip6tables-enabled.rules
 etc/qubes/iptables.rules
 etc/tinyproxy/tinyproxy-updates.conf
 etc/tinyproxy/updates-blacklist

--- a/network/80-qubes.conf
+++ b/network/80-qubes.conf
@@ -1,1 +1,2 @@
 net.ipv4.ip_forward=1
+net.ipv6.conf.all.drop_unsolicited_na=1

--- a/network/ip6tables-enabled
+++ b/network/ip6tables-enabled
@@ -1,0 +1,31 @@
+*nat
+:PREROUTING ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+:PR-QBS - [0:0]
+:PR-QBS-SERVICES - [0:0]
+-A PREROUTING -j PR-QBS
+-A PREROUTING -j PR-QBS-SERVICES
+-A POSTROUTING -o vif+ -j ACCEPT
+-A POSTROUTING -o lo -j ACCEPT
+-A POSTROUTING -j MASQUERADE
+COMMIT
+*filter
+:INPUT DROP [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+:QBS-FORWARD - [0:0]
+-A INPUT -i lo -j ACCEPT
+-A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A INPUT -i vif+ -p icmpv6 --icmpv6-type router-advertisement -j DROP
+-A INPUT -i vif+ -p icmpv6 --icmpv6-type redirect -j DROP
+-A INPUT -i vif+ -p icmpv6 -j ACCEPT
+-A INPUT -i vif+ -j REJECT --reject-with icmp6-adm-prohibited
+-A INPUT -p icmpv6 -j ACCEPT
+-A INPUT -j DROP
+-A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
+-A FORWARD -j QBS-FORWARD
+-A FORWARD -i vif+ -o vif+ -j DROP
+-A FORWARD -i vif+ -j ACCEPT
+-A FORWARD -j DROP
+COMMIT

--- a/network/qubes-iptables
+++ b/network/qubes-iptables
@@ -29,6 +29,15 @@ fi
 start() {
     ipt=$1
     IPTABLES_DATA=$IPTABLES_DATA_DIR/${ipt}.rules
+    ipv6_enabled=
+    if qubesdb-read /qubes-ip6 >/dev/null 2>&1 || \
+        qubesdb-read /qubes-netvm-gateway6 >/dev/null 2>&1; then
+        ipv6_enabled=true
+    fi
+    # if IPv6 is enabled, load alternative rules file
+    if [ "$ipt" = "ip6tables" ] && [ -n "$ipv6_enabled" ]; then
+        IPTABLES_DATA=$IPTABLES_DATA_DIR/${ipt}-enabled.rules
+    fi
     CMD=$ipt
     # Do not start if there is no config file.
     [ ! -f "$IPTABLES_DATA" ] && return 6

--- a/network/setup-ip
+++ b/network/setup-ip
@@ -7,9 +7,11 @@
 have_qubesdb || exit 0
 
 ip=$(/usr/bin/qubesdb-read /qubes-ip 2> /dev/null)
+ip6=$(/usr/bin/qubesdb-read /qubes-ip6 2> /dev/null)
 if [ "x$ip" != x ]; then
     #netmask=$(/usr/bin/qubesdb-read /qubes-netmask)
     gateway=$(/usr/bin/qubesdb-read /qubes-gateway)
+    gateway6=$(/usr/bin/qubesdb-read /qubes-gateway6)
     primary_dns=$(/usr/bin/qubesdb-read /qubes-primary-dns 2>/dev/null || echo "$gateway")
     secondary_dns=$(/usr/bin/qubesdb-read /qubes-secondary-dns)
     /sbin/ethtool -K "$INTERFACE" sg off
@@ -28,32 +30,72 @@ mac-address=$(ip l show dev "$INTERFACE" |grep link|awk '{print $2}')
 id=VM uplink $INTERFACE
 uuid=de85f79b-8c3d-405f-a652-cb4c10b4f9ef
 type=802-3-ethernet
-
-[ipv6]
-method=ignore
-
+__EOF__
+        ip4_nm_config=""
+        ip6_nm_config=""
+        if ! qsvc disable-dns-server ; then
+            ip4_nm_config="${ip4_nm_config}
+dns=${primary_dns};${secondary_dns}"
+        fi
+        if ! qsvc disable-default-route ; then
+            ip4_nm_config="${ip4_nm_config}
+addresses1=$ip;32;$gateway"
+            if [ -n "$ip6" ]; then
+                ip6_nm_config="${ip6_nm_config}
+addresses1=$ip6;128;$gateway6"
+            fi
+        else
+            ip4_nm_config="${ip4_nm_config}
+addresses1=$ip;32"
+            if [ -n "$ip6" ]; then
+                ip6_nm_config="${ip6_nm_config}
+addresses1=$ip6;128"
+            fi
+        fi
+        if [ -n "$ip4_nm_config" ]; then
+            cat >> "$nm_config" <<__EOF__
 [ipv4]
 method=manual
 may-fail=false
+$ip4_nm_config
 __EOF__
-        if ! qsvc disable-dns-server ; then
-            echo "dns=$primary_dns;$secondary_dns" >> "$nm_config"
-        fi
-        if ! qsvc disable-default-route ; then
-            echo "addresses1=$ip;32;$gateway" >> "$nm_config"
         else
-            echo "addresses1=$ip;32" >> "$nm_config"
+            cat >> "$nm_config" <<__EOF__
+[ipv4]
+method=ignore
+__EOF__
         fi
+
+        if [ -n "$ip6_nm_config" ]; then
+            cat >> "$nm_config" <<__EOF__
+[ipv6]
+method=manual
+may-fail=false
+$ip6_nm_config
+__EOF__
+        else
+            cat >> "$nm_config" <<__EOF__
+[ipv6]
+method=ignore
+__EOF__
+        fi
+
         chmod 600 "$nm_config"
         # reload connection
         nmcli connection load "$nm_config" || :
     else
         # No NetworkManager enabled, configure the network manually
         /sbin/ifconfig "$INTERFACE" "$ip" netmask 255.255.255.255
+        if [ -n "$ip6" ]; then
+            /sbin/ifconfig "$INTERFACE" add "$ip6"/128
+        fi
         /sbin/ifconfig "$INTERFACE" up
         /sbin/route add -host "$gateway" dev "$INTERFACE"
         if ! qsvc disable-default-route ; then
             /sbin/route add default gw "$gateway"
+            if [ -n "$gateway6" ]; then
+                /sbin/route -6 add default gw "$gateway6" dev "$INTERFACE"
+            fi
         fi
         if ! is_protected_file /etc/resolv.conf ; then
             echo > /etc/resolv.conf

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -29,8 +29,16 @@ lockfile=/var/run/xen-hotplug/vif-lock
 
 # shellcheck disable=SC2154
 if [ "${ip}" ]; then
+    # get first IPv4 and first IPv6
+    for addr in ${ip}; do
+        if [ -z "$ip4" ] && [[ "$addr" = *.* ]]; then
+            ip4="$addr"
+        elif [ -z "$ip6" ] && [[ "$addr" = *:* ]]; then
+            ip6="$addr"
+        fi
+    done
     # IPs as seen by this VM
-    netvm_ip="$ip"
+    netvm_ip="$ip4"
     netvm_gw_ip=$(qubesdb-read /qubes-netvm-gateway)
     netvm_dns1_ip=$(qubesdb-read /qubes-netvm-primary-dns)
     netvm_dns2_ip=$(qubesdb-read /qubes-netvm-secondary-dns)
@@ -38,12 +46,14 @@ if [ "${ip}" ]; then
     back_ip="$netvm_gw_ip"
 
     # IPs as seen by the VM - if other than $netvm_ip
-    appvm_gw_ip="$(qubesdb-read "/mapped-ip/$ip/visible-gateway" 2>/dev/null || :)"
-    appvm_ip="$(qubesdb-read "/mapped-ip/$ip/visible-ip" 2>/dev/null || :)"
+    appvm_gw_ip="$(qubesdb-read "/mapped-ip/$ip4/visible-gateway" 2>/dev/null || :)"
+    appvm_ip="$(qubesdb-read "/mapped-ip/$ip4/visible-ip" 2>/dev/null || :)"
 fi
 
 # Apply NAT if IP visible from the VM is different than the "real" one
 # See vif-qubes-nat.sh for details
+# XXX: supported only for the first IPv4 address, IPv6 is dropped if this
+# feature is enabled
 if [ -n "$appvm_ip" ] && [ -n "$appvm_gw_ip" ] && [ "$appvm_ip" != "$netvm_ip" ]; then
     # shellcheck disable=SC2154
     if test "$command" == online; then
@@ -83,9 +93,19 @@ if [ "${ip}" ] ; then
 	# the guest using those addresses.
 	for addr in ${ip} ; do
 		${cmdprefix} ip route "${ipcmd}" "${addr}" dev "${vif}" metric "$metric"
+        if [[ "$addr" = *:* ]]; then
+            ipt=ip6tables-restore
+        else
+            ipt=iptables-restore
+        fi
+        echo -e "*raw\n$iptables_cmd -i ${vif} ! -s ${addr} -j DROP\nCOMMIT" | \
+            ${cmdprefix} flock $lockfile $ipt --noflush
 	done
-	echo -e "*raw\n$iptables_cmd -i ${vif} ! -s ${ip} -j DROP\nCOMMIT" | \
-		${cmdprefix} flock $lockfile iptables-restore --noflush
+    # if no IPv6 is assigned, block all IPv6 traffic on that interface
+    if ! [[ "$ip" = *:* ]]; then
+        echo -e "*raw\n$iptables_cmd -i ${vif} -j DROP\nCOMMIT" | \
+            ${cmdprefix} flock $lockfile ip6tables-restore --noflush
+    fi
 	${cmdprefix} ip addr "${ipcmd}" "${back_ip}/32" dev "${vif}"
 fi
 

--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -169,7 +169,7 @@ class IptablesWorker(FirewallWorker):
     @staticmethod
     def chain_for_addr(addr):
         '''Generate iptables chain name for given source address address'''
-        return 'qbs-' + addr.replace('.', '-').replace(':', '-')
+        return 'qbs-' + addr.replace('.', '-').replace(':', '-')[-20:]
 
     def run_ipt(self, family, args, **kwargs):
         # pylint: disable=no-self-use
@@ -236,7 +236,10 @@ class IptablesWorker(FirewallWorker):
                 raise RuleParseError('dst6 rule found for IPv4 address')
 
             if 'proto' in rule:
-                protos = [rule['proto']]
+                if rule['proto'] == 'icmp' and family == 6:
+                    protos = ['icmpv6']
+                else:
+                    protos = [rule['proto']]
             else:
                 protos = None
 

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -162,7 +162,7 @@ class TestIptablesWorker(TestCase):
             self.obj.chain_for_addr('10.137.0.1'), 'qbs-10-137-0-1')
         self.assertEqual(
             self.obj.chain_for_addr('fd09:24ef:4179:0000::3'),
-            'qbs-fd09-24ef-4179-0000--3')
+            'qbs-09-24ef-4179-0000--3')
 
     def test_001_create_chain(self):
         testdata = [
@@ -230,7 +230,7 @@ class TestIptablesWorker(TestCase):
             "-A chain -d 2001::2/128 -p udp --dport 53:53 -j ACCEPT\n"
             "-A chain -d 2001::1/128 -p udp --dport 53:53 -j DROP\n"
             "-A chain -d 2001::2/128 -p udp --dport 53:53 -j DROP\n"
-            "-A chain -p icmp -j DROP\n"
+            "-A chain -p icmpv6 -j DROP\n"
             "-A chain -j DROP\n"
             "COMMIT\n"
         )

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -682,6 +682,7 @@ rm -f %{name}-%{version}
 %files networking
 %config(noreplace) /etc/qubes-rpc/qubes.UpdatesProxy
 %config(noreplace) /etc/qubes/ip6tables.rules
+%config(noreplace) /etc/qubes/ip6tables-enabled.rules
 %config(noreplace) /etc/qubes/iptables.rules
 %config(noreplace) /etc/tinyproxy/tinyproxy-updates.conf
 %config(noreplace) /etc/tinyproxy/updates-blacklist

--- a/vm-systemd/network-proxy-setup.sh
+++ b/vm-systemd/network-proxy-setup.sh
@@ -11,6 +11,7 @@ if [ "x$network" != "x" ]; then
     fi
 
     gateway=$(qubesdb-read /qubes-netvm-gateway)
+    gateway6=$(qubesdb-read /qubes-netvm-gateway6 ||:)
     #netmask=$(qubesdb-read /qubes-netvm-netmask)
     primary_dns=$(qubesdb-read /qubes-netvm-primary-dns 2>/dev/null || echo "$gateway")
     secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
@@ -19,5 +20,9 @@ if [ "x$network" != "x" ]; then
     echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
     /usr/lib/qubes/qubes-setup-dnat-to-ns
     echo "1" > /proc/sys/net/ipv4/ip_forward
+    # enable also IPv6 forwarding, if IPv6 is enabled
+    if [ -n "$gateway6" ]; then
+        echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+    fi
     /sbin/ethtool -K eth0 sg off || true
 fi


### PR DESCRIPTION
When /qubes-ip6 QubesDB entry is present, configure IPv6 address accordingly.
Same for /qubes-gateway6 entry. If IPv6 address is configured, load alternative
IPv6 firewall, which will actually allow IPv6 traffic.
If /qubes-ip6 entry is not present, behaviour should be unchanged.

Fixes QubesOS/qubes-issues#718