### PR TITLE
Disable wpa_supplicant@.service

### DIFF
--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -56,6 +56,7 @@ disable smartd.service
 disable upower.service
 disable colord.service
 disable systemd-timesyncd.service
+disable wpa_supplicant@.service
 
 # Fedora only services
 disable cpuspeed.service


### PR DESCRIPTION
It is responsible for the long start-up delay in Stretch template and is unnecessary. Testing confirms that sys-net templates continue to function as expected without it.(See QubesOS/qubes-issues#2913)

According to the docs, NetworkManager should be using dbus to connect with wpa_supplicant so this should be no loss.

Closes QubesOS/qubes-issues#2913