### PR TITLE
make apt-get apt-transport-tor broken in Qubes non-networked TemplateVMs

### DIFF
--- a/network/update-proxy-configs
+++ b/network/update-proxy-configs
@@ -95,6 +95,7 @@ if [ -d /etc/apt/apt.conf.d ]; then
 ### /etc/apt/apt.conf.d.
 
 Acquire::http::Proxy "$PROXY_ADDR";
+Acquire::tor::proxy "$PROXY_ADDR";
 EOF
     else
         rm -f /etc/apt/apt.conf.d/01qubes-proxy


### PR DESCRIPTION
fixes https://github.com/QubesOS/qubes-issues/issues/3403