### PR TITLE
Stop Debian templates from forwarding by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -306,7 +306,6 @@ install-deb: install-common install-systemd install-systemd-dropins
 	install -D -m 644 network/00notify-hook $(DESTDIR)/etc/apt/apt.conf.d/00notify-hook
 	install -D -m 0644 misc/apt-conf-70no-unattended $(DESTDIR)/etc/apt/apt.conf.d/70no-unattended
 	install -d $(DESTDIR)/etc/sysctl.d
-	install -m 644 network/80-qubes.conf $(DESTDIR)/etc/sysctl.d/
 	install -D -m 644 misc/profile.d_qt_x11_no_mitshm.sh $(DESTDIR)/etc/profile.d/qt_x11_no_mitshm.sh
 	install -D -m 440 misc/sudoers.d_umask $(DESTDIR)/etc/sudoers.d/umask
 	install -d $(DESTDIR)/etc/pam.d

--- a/network/80-qubes.conf
+++ b/network/80-qubes.conf
@@ -1,1 +1,0 @@
-net.ipv4.ip_forward=1


### PR DESCRIPTION
Debian templates currently have ip_forward set to 1.
This PR changes that default.

Closes QubesOS/qubes-issues#3453
