### PR TITLE
Stop Debian templates from forwarding by default.

### DIFF
--- a/network/80-qubes.conf
+++ b/network/80-qubes.conf
@@ -1,2 +1,1 @@
-net.ipv4.ip_forward=1
 net.ipv6.conf.all.drop_unsolicited_na=1


### PR DESCRIPTION
Debian templates currently have ip_forward set to 1.
This PR changes that default.

Closes QubesOS/qubes-issues#3453