### PR TITLE
bind-dirs.sh: don't fail on empty configuration directory

### DIFF
--- a/vm-systemd/bind-dirs.sh
+++ b/vm-systemd/bind-dirs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash -e
+shopt -s nullglob dotglob
 # vim: set ts=4 sw=4 sts=4 et :
 #
 # bind-dirs
@@ -39,8 +40,6 @@ init() {
    [ -n "$rw_dest_dir" ] || rw_dest_dir="/rw/bind-dirs"
    [ -n "$symlink_level_max" ] || symlink_level_max="10"
    mkdir --parents "$rw_dest_dir"
-   shopt -s nullglob
-   shopt -s dotglob
 }
 
 legacy() {


### PR DESCRIPTION
`nullglob` must be active before a glob is used on a potentially empty directory. Call `shopt` immediately after the shebang line.

Fixes QubesOS/qubes-issues#3552