### PR TITLE
network: reload DNS only on "up" event from NetworkManager

### DIFF
--- a/network/qubes-nmhook
+++ b/network/qubes-nmhook
@@ -4,11 +4,13 @@
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
 
-/usr/lib/qubes/qubes-setup-dnat-to-ns
+if [ "$2" = "up" ]; then
+    /usr/lib/qubes/qubes-setup-dnat-to-ns
 
-# FIXME: Tinyproxy does not reload DNS servers.
-if under_systemd ; then
-    systemctl --no-block try-restart qubes-updates-proxy.service
-else
-    service qubes-updates-proxy try-restart
+    # FIXME: Tinyproxy does not reload DNS servers.
+    if under_systemd ; then
+        systemctl --no-block try-restart qubes-updates-proxy.service
+    else
+        service qubes-updates-proxy try-restart
+    fi
 fi


### PR DESCRIPTION
NetworkManager reports a bunch of events, reloading DNS at each of them
doesn't make sense and is harmful - systemd have ratelimit on service
restart.

Fixes QubesOS/qubes-issues#3135