### PR TITLE
Call qubes.PostInstall service to notify dom0 about all apps/features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,6 @@ install-rh: install-systemd install-systemd-dropins install-sysvinit
 	install -d $(DESTDIR)/etc/yum.conf.d
 	touch $(DESTDIR)/etc/yum.conf.d/qubes-proxy.conf
 
-	install -D -m 0644 misc/qubes-trigger-sync-appmenus.action $(DESTDIR)/etc/yum/post-actions/qubes-trigger-sync-appmenus.action
-
 	install -D -m 0644 misc/grub.qubes $(DESTDIR)/etc/default/grub.qubes
 	install -D -m 0644 misc/serial.conf $(DESTDIR)/usr/share/qubes/serial.conf
 	install -D misc/qubes-serial-login $(DESTDIR)/$(SBINDIR)/qubes-serial-login

--- a/archlinux/PKGBUILD.qubes-update-desktop-icons.hook
+++ b/archlinux/PKGBUILD.qubes-update-desktop-icons.hook
@@ -6,6 +6,6 @@ Operation = Remove
 Target = usr/share/applications/*.desktop
 
 [Action]
-Description = Updating the Qubes desktop file App Icons...
+Description = Updating the Qubes desktop file App Icons and features...
 When = PostTransaction
-Exec = /usr/lib/qubes/qubes-trigger-sync-appmenus.sh
+Exec = /etc/qubes-rpc/qubes.PostInstall

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -181,8 +181,8 @@ case "${1}" in
 
         dconf update || true
 
-        # Update Qubes App Menus
-        /usr/lib/qubes/qubes-trigger-sync-appmenus.sh || true
+        # tell dom0 about installed updates (applications, features etc)
+        /etc/qubes-rpc/qubes.PostInstall || true
         ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)
@@ -194,8 +194,8 @@ case "${1}" in
             case "${trigger}" in
 
                 /usr/share/applications)
-                    debug "Updating Qubes App Menus..."
-                    /usr/lib/qubes/qubes-trigger-sync-appmenus.sh || true
+                    debug "Updating Qubes App Menus and advertising features..."
+                    /etc/qubes-rpc/qubes.PostInstall || true
                     ;;
 
                 # Install overridden serial.conf init script

--- a/misc/dnf-qubes-hooks.py
+++ b/misc/dnf-qubes-hooks.py
@@ -61,6 +61,5 @@ class QubesHooks(dnf.Plugin):
                 str(len(updates))
             ])
 
-        if config.getboolean('main', 'sync-appmenus'):
-            self.log.info("Sending application list and icons to dom0")
-            subprocess.call(['/usr/lib/qubes/qubes-trigger-sync-appmenus.sh'])
+        self.log.info("Notifying dom0 about installed applications")
+        subprocess.call(['/etc/qubes-rpc/qubes.PostInstall'])

--- a/misc/qubes-trigger-sync-appmenus.action
+++ b/misc/qubes-trigger-sync-appmenus.action
@@ -1,1 +1,0 @@
-*:any:/usr/lib/qubes/qubes-trigger-sync-appmenus.sh

--- a/post-install.d/README
+++ b/post-install.d/README
@@ -1,3 +1,3 @@
 All executable files with `.sh` suffix in this directory will be executed as
-root just after template installation. Template VM may not have access to the
-network at this time yet.
+root just after template installation or update. Template VM may
+not have access to the network at this time yet.

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -323,10 +323,6 @@ usermod -p '' root
 (cd qrexec; make install DESTDIR=$RPM_BUILD_ROOT)
 make install-vm DESTDIR=$RPM_BUILD_ROOT
 
-%if %{fedora} >= 22
-rm -f $RPM_BUILD_ROOT/etc/yum/post-actions/qubes-trigger-sync-appmenus.action
-%endif
-
 %if 0%{?rhel} >= 7
 sed -i \
         -e 's:-primary:-centos:' \
@@ -612,9 +608,6 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/yum.repos.d/qubes-r4.repo
 /etc/yum/pluginconf.d/yum-qubes-hooks.conf
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
-%if %{fedora} < 22
-/etc/yum/post-actions/qubes-trigger-sync-appmenus.action
-%endif
 %config(noreplace) /etc/dconf/profile/user
 %config(noreplace) /etc/dconf/db/local.d/dpi
 /usr/lib/systemd/system/user@.service.d/90-session-stop-timeout.conf


### PR DESCRIPTION
Update dom0 about all applications installed, not only desktop files for
them. Update also supported features and other things advertised initially
at template installation.

Fixes QubesOS/qubes-issues#3579