### PR TITLE
Really enable qubes-sync-time.timer

### DIFF
--- a/vm-systemd/qubes-sync-time.timer
+++ b/vm-systemd/qubes-sync-time.timer
@@ -6,4 +6,5 @@ ConditionPathExists=!/var/run/qubes-service/clocksync
 OnBootSec=10s
 OnUnitActiveSec=6h
 
-
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
/cc @adrelanos, in case you want to disable the timer in Whonix with a drop-in.