### PR TITLE
Fix CentOS 0/5 (centos: fix conflict with dconf)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -289,8 +289,10 @@ install-common: install-doc
 	install -d $(DESTDIR)/usr/share/nautilus-python/extensions
 	install -m 0644 qubes-rpc/*_nautilus.py $(DESTDIR)/usr/share/nautilus-python/extensions
 
+ifeq ($(findstring CentOS,$(shell cat /etc/redhat-release)),)
 	install -D -m 0644 misc/dconf-profile-user $(DESTDIR)/etc/dconf/profile/user
 	install -D -m 0644 misc/dconf-db-local-dpi $(DESTDIR)/etc/dconf/db/local.d/dpi
+endif
 
 	install -D -m 0755 misc/qubes-desktop-run $(DESTDIR)$(BINDIR)/qubes-desktop-run
 

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -615,8 +615,10 @@ rm -f %{name}-%{version}
 %if %{fedora} < 22
 /etc/yum/post-actions/qubes-trigger-sync-appmenus.action
 %endif
+%if 0%{?fedora} >= 23
 %config(noreplace) /etc/dconf/profile/user
 %config(noreplace) /etc/dconf/db/local.d/dpi
+%endif
 /usr/lib/systemd/system/user@.service.d/90-session-stop-timeout.conf
 /usr/sbin/qubes-serial-login
 /usr/bin/qvm-copy-to-vm


### PR DESCRIPTION
Fix conflicting file /etc/dconf/profile/user between Qubes and CentOS dconf.

Can be backported to r3.2.

This solve the issue related in https://groups.google.com/d/msg/qubes-users/KujLPwDNYCE/sLTpMcT9CAAJ