### PR TITLE
qrexec: launch services in login shell

### DIFF
--- a/qrexec/qubes-rpc-multiplexer
+++ b/qrexec/qubes-rpc-multiplexer
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh -l
 
 # write stderr to both calling party and local log; be very careful about
 # closing file descriptors here - if either stdout or stderr will not be closed


### PR DESCRIPTION
Previously the script was called through shell as:
    execl(shell, "-sh", "-c", "/usr/lib/qubes/qubes-rpc-multiplexer
            ...", 0);
This tells the shell to load login scripts, including /etc/profile.
Since 5512e4eadab846b52883b22c0160d36da60454b3 this is no longer the
case and the script is called directly. Since most services do expect
proper user session initialized (/etc/profile loaded etc), adjust the
script's shebang to behave like a login shell and load those startup
scripts.

Fixes QubesOS/qubes-issues#3615