### PR TITLE
Fix qubes-dom0-update regression by restoring dom0-updates dir

### DIFF
--- a/debian/qubes-core-agent.dirs
+++ b/debian/qubes-core-agent.dirs
@@ -1,4 +1,4 @@
 etc/qubes/protected-files.d
 etc/systemd/system
 lib/modules
-var/lib/qubes
+var/lib/qubes/dom0-updates


### PR DESCRIPTION
This dir was present in 3.2.22 but then got removed from the package. Missing that dir causes a problem for qubes-dom0-update that expects to find that dir existing.

Fixes: QubesOS/qubes-issues#3620
