### PR TITLE
Add misc/qubes-run-terminal to launch any available terminal emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ VERSION := $(shell cat version)
 DIST ?= fc18
 KDESERVICEDIR ?= /usr/share/kde4/services
 KDE5SERVICEDIR ?= /usr/share/kservices5/ServiceMenus/
+APPLICATIONSDIR ?= /usr/share/applications
 SBINDIR ?= /usr/sbin
 BINDIR ?= /usr/bin
 LIBDIR ?= /usr/lib
@@ -227,6 +228,8 @@ install-common: install-doc
 	install -d $(DESTDIR)$(BINDIR)
 	install -m 0755 misc/qubes-session-autostart $(DESTDIR)$(BINDIR)/qubes-session-autostart
 	install -m 0755 misc/qvm-features-request $(DESTDIR)$(BINDIR)/qvm-features-request
+	install -m 0755 misc/qubes-run-terminal $(DESTDIR)/$(BINDIR)
+	install -D -m 0755 misc/qubes-run-terminal.desktop $(DESTDIR)/$(APPLICATIONSDIR)/qubes-run-terminal.desktop
 	install -m 0755 qubes-rpc/qvm-sync-clock $(DESTDIR)$(BINDIR)/qvm-sync-clock
 	install qubes-rpc/{qvm-open-in-dvm,qvm-open-in-vm,qvm-copy-to-vm,qvm-run-vm} $(DESTDIR)/usr/bin
 	install qubes-rpc/qvm-copy $(DESTDIR)/usr/bin

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -92,6 +92,7 @@ lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 usr/bin/qubes-desktop-run
 usr/bin/qubes-open
 usr/bin/qubes-session-autostart
+usr/bin/qubes-run-terminal
 usr/bin/qvm-copy
 usr/bin/qvm-copy-to-vm
 usr/bin/qvm-features-request
@@ -142,6 +143,7 @@ usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 usr/share/glib-2.0/schemas/*
 usr/share/kde4/services/*.desktop
 usr/share/kservices5/ServiceMenus/*.desktop
+usr/share/applications/*.desktop
 usr/share/man/man1/qvm-*
 usr/share/qubes/mime-override/globs
 usr/share/qubes/qubes-master-key.asc

--- a/misc/qubes-run-terminal
+++ b/misc/qubes-run-terminal
@@ -1,0 +1,11 @@
+#!/bin/sh
+# Try to find a terminal emulator that's installed and run it.
+
+for terminal in x-terminal-emulator gnome-terminal xfce4-terminal konsole urxvt rxvt termit terminator Eterm aterm roxterm termite lxterminal mate-terminal terminology st xterm; do
+    if which $terminal >/dev/null 2>&1 ; then
+        exec "$terminal"
+    fi
+done
+
+echo "ERROR: No suitable terminal found." > /dev/stderr
+

--- a/misc/qubes-run-terminal.desktop
+++ b/misc/qubes-run-terminal.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Run Terminal
+Exec=qubes-run-terminal
+Icon=utilities-terminal
+Type=Application

--- a/rpm_spec/core-agent.spec
+++ b/rpm_spec/core-agent.spec
@@ -626,6 +626,7 @@ rm -f %{name}-%{version}
 /usr/bin/qvm-sync-clock
 /usr/bin/xenstore-watch-qubes
 /usr/bin/qubes-desktop-run
+/usr/bin/qubes-run-terminal
 /usr/bin/qubes-open
 /usr/bin/qubes-session-autostart
 %dir /usr/lib/qubes
@@ -665,6 +666,7 @@ rm -f %{name}-%{version}
 %dir /usr/lib/qubes-bind-dirs.d
 /usr/lib/qubes-bind-dirs.d/30_cron.conf
 /usr/lib/python2.7/site-packages/qubesxdg.py*
+/usr/share/applications/qubes-run-terminal.desktop
 /usr/share/qubes/serial.conf
 /usr/share/glib-2.0/schemas/20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.gnome.nautilus.qubes.gschema.override


### PR DESCRIPTION
Requirement for pull request about to be submitted to qubes-desktop-linux-manager, to add "Run Terminal" option to the qui domains tray.

Probably comes in handy in other places as well (Marek pointed out the i3 repo has a similar thing).