### PR TITLE
Handle multiple 'dconf' packaging who include 'user' file.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ SYSTEM_DROPINS_NETWORKING += tinyproxy.service
 
 USER_DROPINS := pulseaudio.service pulseaudio.socket
 
+FEDORA_RELEASE := $(shell awk '{print $$3}' /etc/fedora-release)
+
 # Ubuntu Dropins
 ifeq ($(shell lsb_release -is), Ubuntu)
 
@@ -300,7 +302,9 @@ install-common: install-doc
 	install -m 0644 qubes-rpc/*_nautilus.py $(DESTDIR)/usr/share/nautilus-python/extensions
 
 ifeq ($(findstring CentOS,$(shell cat /etc/redhat-release)),)
+ifeq ($(filter-out 25 26 27,$(FEDORA_RELEASE)),)
 	install -D -m 0644 misc/dconf-profile-user $(DESTDIR)/etc/dconf/profile/user
+endif
 endif
 	install -D -m 0644 misc/dconf-db-local-dpi $(DESTDIR)/etc/dconf/db/local.d/dpi
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -586,7 +586,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/yum.repos.d/qubes-r4.repo
 /etc/yum/pluginconf.d/yum-qubes-hooks.conf
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
-%if 0%{?fedora} >= 23
+%if 0%{?fedora} >= 23 && 0%{?fedora} < 28
 %config(noreplace) /etc/dconf/profile/user
 %endif
 %config(noreplace) /etc/dconf/db/local.d/dpi


### PR DESCRIPTION
For RPM distros, only CentOS and Fedora >=28 include it.