### PR TITLE
Qubes firewall: correct syntax for icmpv6 rejects

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -504,7 +504,7 @@ class NftablesWorker(FirewallWorker):
                 action = 'accept'
             elif rule['action'] == 'drop':
                 action = 'reject with icmp{} type admin-prohibited'.format(
-                    '6' if family == 6 else '')
+                    'v6' if family == 6 else '')
             else:
                 raise RuleParseError(
                     'Invalid rule action {}'.format(rule['action']))

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -411,10 +411,10 @@ class TestNftablesWorker(TestCase):
             '    ip6 daddr { 2001::1/128, 2001::2/128 } tcp dport 53 accept\n'
             '    ip6 daddr { 2001::1/128, 2001::2/128 } udp dport 53 accept\n'
             '    ip6 nexthdr udp ip6 daddr { 2001::1/128, 2001::2/128 } '
-            'udp dport 53 reject with icmp6 type admin-prohibited\n'
-            '    ip6 nexthdr icmpv6 icmpv6 type 128 reject with icmp6 type '
+            'udp dport 53 reject with icmpv6 type admin-prohibited\n'
+            '    ip6 nexthdr icmpv6 icmpv6 type 128 reject with icmpv6 type '
             'admin-prohibited\n'
-            '    reject with icmp6 type admin-prohibited\n'
+            '    reject with icmpv6 type admin-prohibited\n'
             '  }\n'
             '}\n'
         )


### PR DESCRIPTION
I've run into an issue with incorrectly generated rules for IPv6. I
added some debugging code printing the generated rules and the
resulting error (see below). Turns out `reject with` expects `icmpv6`
rather than `icmp6`.

Tested with Fedora 27 and Debian 9.

## Debug Output
```
--- generated rule ---

flush chain ip6 qubes-firewall qbs-fd09-24ef-4179--a89-15
table ip6 qubes-firewall {
  chain qbs-fd09-24ef-4179--a89-15 {
    ip6 daddr fc00::/8 reject with icmp6 type admin-prohibited
    ip6 daddr fd00::/8 reject with icmp6 type admin-prohibited
    ip6 daddr fe80::/10 reject with icmp6 type admin-prohibited
    accept
    reject with icmp6 type admin-prohibited
  }
}

--- output ---

/dev/stdin:4:36-40: Error: syntax error, unexpected string, expecting icmp or icmpv6 or tcp or icmpx

                                   ^^^^^
/dev/stdin:5:36-40: Error: syntax error, unexpected string, expecting icmp or icmpv6 or tcp or icmpx

                                   ^^^^^
/dev/stdin:6:37-41: Error: syntax error, unexpected string, expecting icmp or icmpv6 or tcp or icmpx

                                    ^^^^^
/dev/stdin:8:17-21: Error: syntax error, unexpected string, expecting icmp or icmpv6 or tcp or icmpx

                ^^^^^
```