### PR TITLE
R4.1: Pass GUI domain id to GUI agent

### DIFF
--- a/vm-systemd/qubes-sysinit.sh
+++ b/vm-systemd/qubes-sysinit.sh
@@ -64,9 +64,13 @@ done
 # Prepare environment for other services
 echo > /var/run/qubes-service-environment
 
+gui_opts="-d $(qubesdb-read /qubes-gui-domain-xid || echo 0)"
+
 debug_mode=$(qubesdb-read /qubes-debug-mode 2> /dev/null)
 if [ -n "$debug_mode" ] && [ "$debug_mode" -gt 0 ]; then
-    echo "GUI_OPTS=-vv" >> /var/run/qubes-service-environment
+    gui_opts="$gui_opts -vv"
 fi
+
+echo "GUI_OPTS=$gui_opts" >> /var/run/qubes-service-environment
 
 exit 0


### PR DESCRIPTION
Conflicts with gui-agent-linux without https://github.com/QubesOS/qubes-gui-agent-linux/pull/34.