### PR TITLE
grub: add noresume to kernel cmdline

### DIFF
--- a/misc/grub.qubes
+++ b/misc/grub.qubes
@@ -6,4 +6,7 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX root=/dev/mapper/dmroot console=hvc0 con
 # make SWIOTLB smaller - it isn't really needed unless PCI passthrough is used,
 # and even then, 16MB is enough
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX swiotlb=8192"
+# add noresume - to avoid a 30 second hang on Debian HVM boot as it tries to
+# locate swap space for hibernation
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX noresume"
 GRUB_TIMEOUT=0


### PR DESCRIPTION
Under R4.0, when Debian HVMs are created from the debian-9 template, they hang on boot for 30 seconds without this option.

https://github.com/QubesOS/qubes-issues/issues/3178
