### PR TITLE
bind mount /usr/local

### DIFF
--- a/misc/fstab
+++ b/misc/fstab
@@ -4,6 +4,7 @@
 /dev/mapper/dmroot /                       ext4 defaults,noatime        1 1
 /dev/xvdb		/rw			auto	noauto,defaults,discard	1 2
 /rw/home        /home       none    noauto,bind,defaults 0 0
+/rw/usrlocal        /usr/local       none    noauto,bind,defaults 0 0
 /dev/xvdc1      swap                    swap    defaults        0 0
 tmpfs                   /dev/shm                tmpfs   defaults,size=1G        0 0
 devpts                  /dev/pts                devpts  gid=5,mode=620  0 0

--- a/vm-systemd/mount-dirs.sh
+++ b/vm-systemd/mount-dirs.sh
@@ -13,6 +13,8 @@ if [ -e /dev/xvdb ] ; then mount /rw ; fi
 initialize_home "/rw/home" ifneeded
 echo "Mounting /rw/home onto /home" >&2
 mount /home
+echo "Mounting /rw/usrlocal onto /usr/local" >&2
+mount /usr/local
 # https://github.com/QubesOS/qubes-issues/issues/1328#issuecomment-169483029
 # Do none of the following in a DispVM.
 /usr/lib/qubes/init/bind-dirs.sh


### PR DESCRIPTION
This is a twin PR. Please also see the PR in qubes-linux-template-builder https://github.com/QubesOS/qubes-linux-template-builder/pull/12.

This PR along with its twin changes `/usr/local` from a symlink to a bind mount similar to how `/home` is mounted.

I stumbled upon this because the sandbox in the opam package manager does not mount `/rw/usrlocal`. This meant that `/usr/local` was a dead symlink and that binaries in `/usr/local/bin` was not in PATH inside the sandbox. See https://github.com/ocaml/opam/pull/3446.