### PR TITLE
Add proper help text to qvm-copy tools and fix incorrect behavior for qvm-move

### DIFF
--- a/qubes-rpc/qvm-copy-to-vm
+++ b/qubes-rpc/qvm-copy-to-vm
@@ -22,7 +22,23 @@ set -e
 #
 
 if [ $# -lt 2 ] ; then
-	echo "usage: $0 [--without-progress] dest_vmname file [file]+"
+	
+	if [ "${0##*/}" = "qvm-move-to-vm" ] || [ "${0##*/}" = "qvm-copy-to-vm" ]; then
+		echo "usage: $0 [--without-progress] destination_vmname FILE [FILE ...]"
+	else
+		echo "usage: $0 [--without-progress] FILE [FILE ...]"
+	fi
+	
+	echo
+
+	if [ "${0##*/}" = "qvm-move-to-vm" ] || [ "${0##*/}" = "qvm-move" ] ; then
+		echo "Move FILE to ~/QubesIncoming/$(hostname)/ in the destination qube."
+	else
+		echo "Copy FILE to ~/QubesIncoming/$(hostname)/ in the destination qube."
+	fi
+	
+	echo 
+	echo "You will be prompted to select the destination qube. If FILE is a directory, it will be copied recursively."	
 	exit 1
 fi
 
@@ -49,6 +65,6 @@ fi
 
 /usr/lib/qubes/qrexec-client-vm "$VM" qubes.Filecopy /usr/lib/qubes/qfile-agent "$@"
 
-if [ "${0##*/}" = "qvm-move-to-vm" ]; then
+if [ "${0##*/}" = "qvm-move-to-vm" ] || [ "${0##*/}" = "qvm-move" ] ; then
 	rm -rf -- "$@"
 fi

--- a/qubes-rpc/qvm-copy-to-vm
+++ b/qubes-rpc/qvm-copy-to-vm
@@ -22,23 +22,23 @@ set -e
 #
 
 if [ $# -lt 2 ] ; then
-	
+
 	if [ "${0##*/}" = "qvm-move-to-vm" ] || [ "${0##*/}" = "qvm-copy-to-vm" ]; then
-		echo "usage: $0 [--without-progress] destination_vmname FILE [FILE ...]"
+		echo "usage: $0 [--without-progress] destination_qube_name FILE [FILE ...]"
 	else
 		echo "usage: $0 [--without-progress] FILE [FILE ...]"
 	fi
-	
+
 	echo
 
 	if [ "${0##*/}" = "qvm-move-to-vm" ] || [ "${0##*/}" = "qvm-move" ] ; then
-		echo "Move FILE to ~/QubesIncoming/$(hostname)/ in the destination qube."
+		echo "Move FILE to ~/QubesIncoming/[THIS QUBE'S NAME]/ in the destination qube."
 	else
-		echo "Copy FILE to ~/QubesIncoming/$(hostname)/ in the destination qube."
+		echo "Copy FILE to ~/QubesIncoming/[THIS QUBE'S NAME]/ in the destination qube."
 	fi
-	
-	echo 
-	echo "You will be prompted to select the destination qube. If FILE is a directory, it will be copied recursively."	
+
+	echo
+	echo "You will be prompted to select the destination qube. If FILE is a directory, it will be copied recursively."
 	exit 1
 fi
 


### PR DESCRIPTION
Added more descriptive usage text to the
qvm-copy/qvm-move/qvm-copy-to-vm/qvm-move-to-vm family of tools.
Also fixed bug that removed the file being moved for qvm-move-to-vm,
but not for qvm-move.

fixes QubesOS/qubes-issues#3529
fixes QubesOS/qubes-issues#4020