### PR TITLE
Install qubes control files for services in Ubuntu templates

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -12,18 +12,8 @@ endif
 source-debian-quilt-copy-in: VERSION = $(shell cat $(ORIG_SRC)/version)
 source-debian-quilt-copy-in: ORIG_FILE = "$(CHROOT_DIR)/$(DIST_SRC)/../qubes-core-agent_$(VERSION).orig.tar.gz"
 source-debian-quilt-copy-in:
-	if [ $(DISTRIBUTION) == qubuntu ] ; then \
-		sed -i /avahi-daemon.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
-		sed -i /exim4.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
-		sed -i /netfilter-persistent.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install ;\
-	fi
 	if [ $(DIST) == trusty ] ; then \
 		sed -i /locales-all/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\
-	fi
-	if [ $(DIST) == xenial ] ; then \
-		sed -i /avahi-daemon.service.d/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install;\
-		sed -i /exim4/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install;\
-		sed -i /netfilter-persistent/d $(CHROOT_DIR)/$(DIST_SRC)/debian/qubes-core-agent.install;\
 	fi
 	if [ $(DIST) == zesty ] ; then \
 		sed -i /initscripts/d $(CHROOT_DIR)/$(DIST_SRC)/debian/control ;\


### PR DESCRIPTION
This effectively reverts the commits in https://github.com/QubesOS/qubes-core-agent-linux/commit/80b5c942069710f75aa7faea141e31c1cba60b33 and https://github.com/QubesOS/qubes-core-agent-linux/commit/54867b6eabed3a6dca0e932ff77f67aedfe43e03 which now prevent Xenial (and later) templates from being built.
There's no reason why those control files should not be installed.

Closes QubesOS/qubes-issues/issues/3871