### PR TITLE
misc/qubes-run-terminal: which -> type

### DIFF
--- a/misc/qubes-run-terminal
+++ b/misc/qubes-run-terminal
@@ -2,10 +2,11 @@
 # Try to find a terminal emulator that's installed and run it.
 
 for terminal in x-terminal-emulator gnome-terminal xfce4-terminal konsole urxvt rxvt termit terminator Eterm aterm roxterm termite lxterminal mate-terminal terminology st xterm; do
-    if which $terminal >/dev/null 2>&1 ; then
+    # bogus warning from ShellCheck < 0.5.0
+    # shellcheck disable=SC2039
+    if type "$terminal" >/dev/null 2>&1 ; then
         exec "$terminal"
     fi
 done
 
-echo "ERROR: No suitable terminal found." > /dev/stderr
-
+echo "ERROR: No suitable terminal found." >&2


### PR DESCRIPTION
`which` is an external tool, `type` is a shell builtin. Using the latter shaves off a bit of latency.

Also use the already open stderr file descriptor for redirection.