### PR TITLE
Install Debian version of qrexec pam in Ubuntu templates

### DIFF
--- a/qrexec/Makefile
+++ b/qrexec/Makefile
@@ -21,6 +21,8 @@ install:
 	install qubes-rpc-multiplexer $(DESTDIR)/usr/lib/qubes
 ifeq ($(shell lsb_release -is), Debian)
 	install -D -m 0644 qrexec.pam.debian $(DESTDIR)/etc/pam.d/qrexec
+else ifeq ($(shell lsb_release -is), Ubuntu)
+	install -D -m 0644 qrexec.pam.debian $(DESTDIR)/etc/pam.d/qrexec
 else ifeq ($(shell lsb_release -is), Arch)
 	install -D -m 0644 qrexec.pam.archlinux $(DESTDIR)/etc/pam.d/qrexec
 else


### PR DESCRIPTION
Closes QubesOS/qubes-issues#4261
