### PR TITLE
Voice informational messages in bind-dirs.sh

### DIFF
--- a/vm-systemd/bind-dirs.sh
+++ b/vm-systemd/bind-dirs.sh
@@ -31,7 +31,7 @@ source /usr/lib/qubes/init/functions
 
 prerequisite() {
    if ! is_rwonly_persistent ; then
-      true "No TemplateBasedVM detected. Exiting."
+      echo "No TemplateBasedVM detected. Exiting."
       exit 0
    fi
 }
@@ -68,7 +68,7 @@ bind_dirs() {
             fso_real_location="$(realpath "$fso_ro")"
             fso_ro="$fso_real_location"
          else
-            true "$fso_ro is not a symlink"
+            echo "$fso_ro is not a symlink"
             break
          fi
          if [ "$symlink_level_counter" -ge "$symlink_level_max" ]; then
@@ -99,7 +99,7 @@ bind_dirs() {
             echo "Initializing $rw_dest_dir with files from $fso_ro" >&2
             cp --archive --recursive --parents "$fso_ro" "$rw_dest_dir"
          else
-            true "$fso_ro is neither a directory nor a file and the path does not exist below /rw, skipping."
+            echo "$fso_ro is neither a directory nor a file and the path does not exist below /rw, skipping."
             continue
          fi
       fi


### PR DESCRIPTION
Previously, bind-dirs.sh had a bunch of `true comment goes here` style debug messages (no-ops). Presumably this was done because these messages are intended as debug messages and would only be displayed when calling bind-dirs.sh with xtrace enabled. However, this includes some fatal errors, which are necessary to debug why bind-dirs.sh is ostensibly not working. For example, I tried to mount /var/lib/docker, didn't realize it did not exist (as an empty directory) in my base template, and there was no journalctl output at all. After this change, journalctl will contain the (very helpful) error message.