### PR TITLE
Remove qubes-core-agent Debian dependency on xserver

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -48,13 +48,10 @@ Depends:
     qubes-core-agent-qrexec,
     qubesdb-vm,
     systemd,
-    x11-xserver-utils,
     xdg-user-dirs,
     xdg-utils,
     xen-utils-common,
     xenstore-utils,
-    xinit,
-    xserver-xorg-core,
     ${python:Depends},
     ${shlibs:Depends},
     ${misc:Depends}
@@ -71,6 +68,9 @@ Recommends:
     qubes-core-agent-nautilus,
     qubes-core-agent-networking,
     qubes-core-agent-network-manager,
+    x11-xserver-utils,
+    xinit,
+    xserver-xorg-core,
     xsettingsd
 Conflicts: qubes-core-agent-linux, firewalld, qubes-core-vm-sysvinit
 Description: Qubes core agent


### PR DESCRIPTION
Mark xserver, xinit and x11-xserver-utils as Recommends.

Tested this for some time and everything seems fine in headless system.

Closes QubesOS/qubes-issues#4202
