### PR TITLE
spec: require 'hostname' as newer Fedora as moved out the dependency …

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -118,6 +118,7 @@ Requires:   initscripts
 Requires:   gawk
 Requires:   sed
 Requires:   util-linux
+Requires:   hostname
 # for qubes-desktop-run
 Requires:   pygobject3-base
 Requires:   dbus-python


### PR DESCRIPTION
…of initscripts into its network subpackage