### PR TITLE
make iproute2 a dependency for Debian core-networking

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -132,6 +132,7 @@ Depends:
     ethtool,
     socat,
     tinyproxy,
+    iproute2,
     ${python:Depends},
     ${misc:Depends}
 Suggests:


### PR DESCRIPTION
Closes  QubesOS/Qubes-issues#4411