### PR TITLE
FIx rootfs resize script

### DIFF
--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -14,7 +14,9 @@ fi
 sysfs_xvda="/sys/class/block/xvda"
 
 # if root filesystem use already (almost) the whole dis
-size_margin=$(( 250 * 1024 * 2 ))
+# 203M for BIOS and /boot data, 222 for ext4 filesystem overhead
+# See QubesOS/qubes-core-agent-linux#146 for more details
+size_margin=$(((222 + 203) * 2 * 1024))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1 | tr -d ' ')
 if [ $(cat $sysfs_xvda/size) -lt \
        $(( size_margin + rootfs_size )) ]; then

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -15,7 +15,7 @@ sysfs_xvda="/sys/class/block/xvda"
 
 # if root filesystem use already (almost) the whole dis
 non_rootfs_data=$(( 250 * 1024 * 2 ))
-rootfs_size=$(df --block-size=512 --output=size / | tail -n 1)
+rootfs_size=$(df --block-size=512 --output=size / | tail -n 1 | tr -d ' ')
 if [ $(cat $sysfs_xvda/size) -gt \
        $(( non_rootfs_data + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -16,7 +16,7 @@ sysfs_xvda="/sys/class/block/xvda"
 # if root filesystem use already (almost) the whole dis
 non_rootfs_data=$(( 250 * 1024 * 2 ))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1)
-if [ "$(cat "$sysfs_xvda/size")" -lt \
+if [ $(cat $sysfs_xvda/size) -lt \
        $(( non_rootfs_data + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2
    exit 0

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -16,7 +16,7 @@ sysfs_xvda="/sys/class/block/xvda"
 # if root filesystem use already (almost) the whole dis
 non_rootfs_data=$(( 250 * 1024 * 2 ))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1)
-if [ $(cat $sysfs_xvda/size) -lt \
+if [ $(cat $sysfs_xvda/size) -gt \
        $(( non_rootfs_data + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2
    exit 0

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -18,7 +18,7 @@ sysfs_xvda="/sys/class/block/xvda"
 # See QubesOS/qubes-core-agent-linux#146 for more details
 size_margin=$(((222 + 203) * 2 * 1024))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1 | tr -d ' ')
-if [ $(cat $sysfs_xvda/size) -lt \
+if [ "$(cat $sysfs_xvda/size)" -lt \
        $(( size_margin + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2
    exit 0

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -14,10 +14,10 @@ fi
 sysfs_xvda="/sys/class/block/xvda"
 
 # if root filesystem use already (almost) the whole dis
-non_rootfs_data=$(( 250 * 1024 * 2 ))
+size_margin=$(( 250 * 1024 * 2 ))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1 | tr -d ' ')
 if [ $(cat $sysfs_xvda/size) -gt \
-       $(( non_rootfs_data + rootfs_size )) ]; then
+       $(( size_margin + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2
    exit 0
 fi

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -15,9 +15,7 @@ sysfs_xvda="/sys/class/block/xvda"
 
 # if root filesystem use already (almost) the whole dis
 non_rootfs_data=$(( 250 * 1024 * 2 ))
-rootfs_size=$(df --output=size / | tail -n 1)
-# convert to 512-byte blocks
-rootfs_size=$(( rootfs_size * 2 ))
+rootfs_size=$(df --block-size=512 --output=size / | tail -n 1)
 if [ "$(cat "$sysfs_xvda/size")" -lt \
        $(( non_rootfs_data + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2

--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -16,7 +16,7 @@ sysfs_xvda="/sys/class/block/xvda"
 # if root filesystem use already (almost) the whole dis
 size_margin=$(( 250 * 1024 * 2 ))
 rootfs_size=$(df --block-size=512 --output=size / | tail -n 1 | tr -d ' ')
-if [ $(cat $sysfs_xvda/size) -gt \
+if [ $(cat $sysfs_xvda/size) -lt \
        $(( size_margin + rootfs_size )) ]; then
    echo "root filesystem already at $rootfs_size blocks" >&2
    exit 0


### PR DESCRIPTION
It was just being compared the wrong way; the rest of these are cleanups. At least, assuming I understand the script right - `non_rootfs_data` is just supposed to be a small margin for error right? I.e. that's what's meant by "(almost) the whole disk"?

It took me a while to get that so I renamed the variable to make it clearer although I'm not sure the new name is _all_ that much better... happy to either drop that commit or amend it to something else.

Fixes QubesOS/qubes-issues#4553 (and improves VM boot performance a _lot_ in the process; it shaves several entire seconds off boot times which especially adds up when all autostart VMs are being brought up at dom0 boot)