### PR TITLE
Add XTerm as a dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -71,7 +71,8 @@ Recommends:
     x11-xserver-utils,
     xinit,
     xserver-xorg-core,
-    xsettingsd
+    xsettingsd,
+    xterm
 Conflicts: qubes-core-agent-linux, firewalld, qubes-core-vm-sysvinit
 Description: Qubes core agent
  This package includes various daemons necessary for qubes domU support,

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -119,6 +119,8 @@ Requires:   gawk
 Requires:   sed
 Requires:   util-linux
 Requires:   hostname
+# for Qubes Manager VM updater
+Requires:   xterm
 # for qubes-desktop-run
 Requires:   pygobject3-base
 Requires:   dbus-python


### PR DESCRIPTION
Qubes Manager's update button fails in strange ways without it.