### PR TITLE
qrexec: add startup notification

### DIFF
--- a/vm-systemd/qubes-qrexec-agent.service
+++ b/vm-systemd/qubes-qrexec-agent.service
@@ -3,6 +3,7 @@ Description=Qubes remote exec agent
 After=xendriverdomain.service
 
 [Service]
+Type=notify
 ExecStartPre=/bin/sh -c '[ -e /dev/xen/evtchn ] || modprobe xen_evtchn'
 ExecStart=/usr/lib/qubes/qrexec-agent
 


### PR DESCRIPTION
Avoid race conditions with services ordered shortly after qrexec start.
Make systemd know when qrexec-agent is really ready to serve.

Fixes QubesOS/qubes-issues#3985