### PR TITLE
Introduce /usr/share/qubes/marker-vm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,8 @@ install-common: install-doc
 	install -d $(DESTDIR)/usr/lib/qubes-bind-dirs.d
 	install -D -m 0644 misc/30_cron.conf $(DESTDIR)/usr/lib/qubes-bind-dirs.d/30_cron.conf
 
+	install -D -m 0644 misc/marker-vm $(DESTDIR)/usr/share/qubes/marker-vm
+
 
 	install -d $(DESTDIR)/var/run/qubes
 	install -d $(DESTDIR)/rw

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -145,3 +145,4 @@ usr/share/applications/*.desktop
 usr/share/man/man1/qvm-*
 usr/share/qubes/mime-override/globs
 usr/share/qubes/qubes-master-key.asc
+usr/share/qubes/marker-vm

--- a/misc/marker-vm
+++ b/misc/marker-vm
@@ -1,0 +1,1 @@
+# This is just a marker file for Qubes OS VM.

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -668,6 +668,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes-bind-dirs.d/30_cron.conf
 /usr/share/applications/qubes-run-terminal.desktop
 /usr/share/qubes/serial.conf
+/usr/share/qubes/marker-vm
 /usr/share/glib-2.0/schemas/20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.gnome.nautilus.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.mate.NotificationDaemon.qubes.gschema.override


### PR DESCRIPTION
Make it easy for packages to detect Qubes VM.

Fixes QubesOS/qubes-issues#1963