### PR TITLE
Handle tinyproxy path changed since Fedora 30+

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -312,6 +312,11 @@ sed -i \
         $RPM_BUILD_ROOT/etc/yum.repos.d/qubes-*.repo
 %endif
 
+%if 0%{?fedora} >= 30
+sed -i 's#^ExecStart=/usr/sbin/tinyproxy#ExecStart=/usr/bin/tinyproxy#' \
+        $RPM_BUILD_ROOT/lib/systemd/system/qubes-updates-proxy.service
+%endif
+
 %triggerin -- initscripts
 if [ -e /etc/init/serial.conf ]; then
 	cp /usr/share/qubes/serial.conf /etc/init/serial.conf

--- a/vm-systemd/qubes-updates-proxy.service
+++ b/vm-systemd/qubes-updates-proxy.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Qubes updates proxy (tinyproxy)
-ConditionPathExists=|/var/run/qubes-service/qubes-yum-proxy
 ConditionPathExists=|/var/run/qubes-service/qubes-updates-proxy
 After=qubes-iptables.service
 


### PR DESCRIPTION
QubesOS/qubes-issues#4973