### PR TITLE
install jitterentropy-rngd by default

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -61,6 +61,7 @@ Recommends:
     gnome-terminal,
     gnome-themes-standard,
     haveged,
+    jitterentropy-rngd,
     libnotify-bin,
     locales-all,
     mate-notification-daemon,


### PR DESCRIPTION
Add `jitterentropy-rngd` as `Recommends:` to package `qubes-core-agent`.

https://github.com/QubesOS/qubes-issues/issues/4169