### PR TITLE
Fish fix

### DIFF
--- a/init/functions
+++ b/init/functions
@@ -35,18 +35,6 @@ systemd_version_changed() {
     return 0
 }
 
-possibly_run_save_script() {
-    ENCODED_SCRIPT=$(qubesdb-read /qubes-save-script)
-    if [ -z "$ENCODED_SCRIPT" ] ; then return ; fi
-    tmpfile=$(mktemp /tmp/qubes-save-script.XXXXXXXXX)
-    echo "$ENCODED_SCRIPT"|base64 -d >"$tmpfile"
-    chmod 755 "$tmpfile"
-    DISPLAY=:0 su - user -c "$tmpfile"
-    ret=$?
-    rm -f "$tmpfile"
-    return $ret
-}
-
 have_qubesdb() {
     # Tests whether qubesdb-read exists and can be executed.
     type qubesdb-read >/dev/null 2>&1

--- a/qubes-rpc/qubes.InstallUpdatesGUI
+++ b/qubes-rpc/qubes.InstallUpdatesGUI
@@ -17,7 +17,7 @@ elif [ -e /etc/arch-release ]; then
 else
     update_cmd='echo Unsupported distribution, install updates manually; bash -i'
 fi
-xterm -title update -e su -l -c "$update_cmd; echo Done.; test -f /var/run/qubes/this-is-templatevm && { echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff; } ;"
+xterm -title update -e su -s /bin/sh -l -c "$update_cmd; echo Done.; test -f /var/run/qubes/this-is-templatevm && { echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff; } ;"
 
 # Notify dom0 about installed updates
-su -c 'service qubes-update-check start'
+su -s /bin/sh -c 'service qubes-update-check start'

--- a/qubes-rpc/qubes.WaitForSession
+++ b/qubes-rpc/qubes.WaitForSession
@@ -10,7 +10,7 @@ cmd='echo $$ >> /tmp/qubes-session-waiter; [ ! -f /tmp/qubes-session-env ] && ex
 if [ "$(id -un)" = "$USERNAME" ]; then
     sh -c "$cmd" 2>/dev/null
 else
-    su -c "$cmd" - "$USERNAME" 2> /dev/null
+    su -s /bin/sh -c "$cmd" - "$USERNAME" 2> /dev/null
 fi
 # the above line is _expected_ to be terminated by a signal, don't treat this as a failure
 exit 0


### PR DESCRIPTION
Specify expected shell in su calls
    
When calling su with a specific script, specify /bin/sh shell to be sure
to use posix compliant shell. User shell may not be a one (like fish).
    
Fixes QubesOS/qubes-issues#5135