### PR TITLE
Allow passwordless login for user "user" (when using 'sudo xl console').

### DIFF
--- a/debian/qubes-core-agent.preinst
+++ b/debian/qubes-core-agent.preinst
@@ -51,6 +51,10 @@ if [ "$1" = "install" ] ; then
     }
     usermod -L -a --groups qubes user
 
+    ## Allow passwordless login for user "user" (when using 'sudo xl console').
+    ## https://github.com/QubesOS/qubes-issues/issues/1130
+    usermod --password '' user
+
     # --------------------------------------------------------------------------
     # Remove `mesg` from root/.profile?
     # --------------------------------------------------------------------------


### PR DESCRIPTION
https://github.com/QubesOS/qubes-issues/issues/1130

Running `sudo usermod --password '' user` in debian-10 TemplateVM allowed me to login as user "user" using `sudo xl console`. While untested, I am pretty sure this would work in the next template build too.