### PR TITLE
Allow passwordless login for user "user" (when using 'sudo xl console').

### DIFF
--- a/debian/qubes-core-agent-passwordless-root.preinst
+++ b/debian/qubes-core-agent-passwordless-root.preinst
@@ -34,7 +34,10 @@ set -e
 # the debian-policy package
 
 if [ "$1" = "install" ] ; then
-    usermod -p '' root
+    usermod --password '' root
+    ## Allow passwordless login for user "user" (when using 'sudo xl console').
+    ## https://github.com/QubesOS/qubes-issues/issues/1130
+    usermod --password '' user
 fi
 
 # dh_installdeb will replace this with shell code automatically


### PR DESCRIPTION
use long option names by default.

https://github.com/QubesOS/qubes-issues/issues/1130