### PR TITLE
Fix misleading error message on rootfs resize

### DIFF
--- a/misc/resize-rootfs
+++ b/misc/resize-rootfs
@@ -13,6 +13,7 @@ case "$(stat -Lc %t:%T /dev/mapper/dmroot)" in
         # and reload partition table; prefer partprobe over blockdev
         # --rereadpt, as it works on mounted partitions
         partprobe /dev/xvda
+        udevadm settle
         ;;
     ca:*)
         echo "Unsupported partition layout, resize it manually" >&2

--- a/misc/resize-rootfs
+++ b/misc/resize-rootfs
@@ -9,7 +9,7 @@ case "$(stat -Lc %t:%T /dev/mapper/dmroot)" in
         ;;
     ca:3)
         # resize partition table itself and xda3 partition
-        echo ',+' | sfdisk --no-reread -q -N 3 /dev/xvda
+        echo ',+' | sfdisk --no-reread --no-tell-kernel -q -N 3 /dev/xvda
         # and reload partition table; prefer partprobe over blockdev
         # --rereadpt, as it works on mounted partitions
         partprobe /dev/xvda

--- a/patches.debian/0001-Revert-Use-sfdisk-instead-of-parted-to-resize-root-p.patch
+++ b/patches.debian/0001-Revert-Use-sfdisk-instead-of-parted-to-resize-root-p.patch
@@ -25,7 +25,7 @@ index 1c2fca3c..bebf1011 100755
          ;;
      ca:3)
 -        # resize partition table itself and xda3 partition
--        echo ',+' | sfdisk --no-reread -q -N 3 /dev/xvda
+-        echo ',+' | sfdisk --no-reread --no-tell-kernel -q -N 3 /dev/xvda
 +        # resize partition table itself
 +        # use undocumented ---pretend-input-tty (yes, three '-') to
 +        # force unattended operation, otherwise it aborts on first


### PR DESCRIPTION
The partition being extended is in use and sfdisk can't reload such
partition table. Tell it to not even try, it will be done by partprobe
call below.

This is not yet complete, OpenQA reports also another issue:

    open: No such file or directory while opening /dev/mapper/dmroot

Happens on Whonix only