### PR TITLE
archlinux: fix proxy setting in XferCommand

### DIFF
--- a/network/update-proxy-configs
+++ b/network/update-proxy-configs
@@ -123,7 +123,7 @@ if [ -d /etc/pacman.d ]; then
 ### If you want to override some of this settings, create another file under 
 ### /etc/pacman.d
 [options]
-XferCommand = ALL_PROXY=$PROXY_ADDR /usr/bin/curl -C - -f %u > %o
+XferCommand = /usr/bin/env ALL_PROXY=$PROXY_ADDR /usr/bin/curl -C - -f -o %o %u
 EOF
     else
         rm -r /etc/pacman.d/01-qubes-proxy.conf


### PR DESCRIPTION
Starting from pacman v5.2.0 there is a problem with updating/installing
new packages:

$ pacman -Sy
...
debug: running command: ALL_PROXY=http://127.0.0.1:8082/ /usr/bin/curl -C - -f https://gluttony.sin.cvut.cz/arch/core/os/x86_64/core.db > /var/lib/pacman/sync/core.db.part
warning: running XferCommand: fork failed!
...

The problem is caused by change in pacman "run XferCommand via exec" [0].


Refs.:
- [0] https://git.archlinux.org/pacman.git/commit/?id=808a4f15ce82d2ed7eeb06de73d0f313620558ee
- [1] https://github.com/QubesOS/qubes-issues/issues/5443