### PR TITLE
Raw USB devices may be used by the primary user

### DIFF
--- a/misc/udev-qubes-misc.rules
+++ b/misc/udev-qubes-misc.rules
@@ -1,1 +1,2 @@
 SUBSYSTEM=="memory", ACTION=="add", ATTR{state}=="offline", ATTR{state}="online"
+SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", GROUP="qubes"


### PR DESCRIPTION
Some devices & programs (like Android's debug bridge `adb`) cannot presently be used in qubes without special knowledge and modification. This PR intends to make all USB devices usable by the system operator.

## Before: ##
```
crw-rw---- 1 root root 189, 4 Nov 16 09:55 /dev/bus/usb/001/005
```

## After: ##
```
crw-rw---- 1 root qubes 189, 4 Nov 16 09:55 /dev/bus/usb/001/005
```
