### PR TITLE
Enable clocksync by default on netVMs

### DIFF
--- a/vm-systemd/qubes-sysinit.sh
+++ b/vm-systemd/qubes-sysinit.sh
@@ -5,7 +5,7 @@
 . /usr/lib/qubes/init/functions
 
 # List of services enabled by default (in case of absence of qubesdb entry)
-DEFAULT_ENABLED_NETVM="network-manager qubes-network qubes-update-check qubes-updates-proxy meminfo-writer qubes-firewall"
+DEFAULT_ENABLED_NETVM="network-manager qubes-network qubes-update-check qubes-updates-proxy meminfo-writer qubes-firewall clocksync"
 DEFAULT_ENABLED_PROXYVM="qubes-network qubes-firewall qubes-update-check meminfo-writer"
 DEFAULT_ENABLED_APPVM="cups qubes-update-check meminfo-writer"
 DEFAULT_ENABLED_TEMPLATEVM="$DEFAULT_ENABLED_APPVM updates-proxy-setup"


### PR DESCRIPTION
The file /var/run/qubes-service/clocksync was missing on the netVM,

```
ls /var/run/qubes-service/
network-manager  qubes-firewall  qubes-network	qubes-update-check  qubes-updates-proxy
```

leading to systemd-timesyncd failing to start on the netVM, 

```
systemctl status systemd-timesyncd
● systemd-timesyncd.service - Network Time Synchronization
   Loaded: loaded (/usr/lib/systemd/system/systemd-timesyncd.service; enabled; vendor preset: enabled)
  Drop-In: /usr/lib/systemd/system/systemd-timesyncd.service.d
           └─30_qubes.conf
   Active: inactive (dead)
Condition: start condition failed at Sun 2019-11-24 20:36:22 CET; 44min ago
           └─ ConditionPathExists=/var/run/qubes-service/clocksync was not met
     Docs: man:systemd-timesyncd.service(8)
```

in turn leading to incorrect time and date everywhere. This commit may fix
that. (I admit I do not understand the structure of the QubesOS code repositories well, so the fix for this may be different)

Bug observed on a fresh install of Qubes 4.0.2-rc2.

Related issues:

- https://github.com/QubesOS/qubes-issues/issues/4939
- possibly other time-out-of-sync issues