### PR TITLE
GetAppmenus: ensure right app directories

### DIFF
--- a/qubes-rpc/qubes.GetAppmenus
+++ b/qubes-rpc/qubes.GetAppmenus
@@ -6,6 +6,15 @@
 #  - directories stored on /rw in case of "rw-only" persistence
 #  - nothing, otherwise
 
+# Reload scripts in /etc/profile.d/, in case they register additional
+# directories in XDG_DATA_DIRS and we forgot them
+# (e.g. because we are running under sudo).
+for i in /etc/profile.d/*.sh ; do
+    if [ -r "$i" ]; then
+        . "$i" >/dev/null
+    fi
+done
+
 if [ -z "$XDG_DATA_HOME" ]; then
     XDG_DATA_HOME="$HOME/.local/share"
 fi

--- a/qubes-rpc/qubes.GetAppmenus
+++ b/qubes-rpc/qubes.GetAppmenus
@@ -11,6 +11,7 @@
 # (e.g. because we are running under sudo).
 for i in /etc/profile.d/*.sh ; do
     if [ -r "$i" ]; then
+        # shellcheck disable=SC1090
         . "$i" >/dev/null
     fi
 done

--- a/qubes-rpc/qubes.GetAppmenus
+++ b/qubes-rpc/qubes.GetAppmenus
@@ -17,7 +17,13 @@ for i in /etc/profile.d/*.sh ; do
 done
 
 if [ -z "$XDG_DATA_HOME" ]; then
-    XDG_DATA_HOME="$HOME/.local/share"
+    user="$(whoami)"
+    # In case we are running under sudo, use default-user.
+    if [ "$user" = "root" ]; then
+        user="$(qubesdb-read /default-user || echo user)"
+    fi
+    home="$(eval echo "~$user")"
+    XDG_DATA_HOME="$home/.local/share"
 fi
 if [ -z "$XDG_DATA_DIRS" ]; then
     XDG_DATA_DIRS="/usr/local/share/:/usr/share/"


### PR DESCRIPTION
The script depends on XDG_DATA_DIRS environment variable
being set up correctly, which is not the case when it is
running under sudo. As a result, a post-install trigger
for apt could remove application entries from other sources
(Snap, Flatpak).

Fixes QubesOS/qubes-issues#5477.