### PR TITLE
Added "QubesIncoming" shortcut to Nautilus

### DIFF
--- a/debian/qubes-core-agent-nautilus.install
+++ b/debian/qubes-core-agent-nautilus.install
@@ -1,1 +1,2 @@
 usr/share/nautilus-python/extensions/*
+usr/lib/qubes/qvm_nautilus_bookmark.sh

--- a/qubes-rpc/nautilus/Makefile
+++ b/qubes-rpc/nautilus/Makefile
@@ -1,7 +1,9 @@
 NAUTILUSPYEXTDIR ?= /usr/share/nautilus-python/extensions
+QUBESLIBDIR ?= /usr/lib/qubes
 
 .PHONY: install
 
 install:
 	install -d $(DESTDIR)$(NAUTILUSPYEXTDIR)
 	install -t $(DESTDIR)$(NAUTILUSPYEXTDIR) -m 0644 *.py
+	install -t $(DESTDIR)$(QUBESLIBDIR) -m 0755 *.sh

--- a/qubes-rpc/nautilus/qvm_nautilus_bookmark.sh
+++ b/qubes-rpc/nautilus/qvm_nautilus_bookmark.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+if [ ! -e ~/.config/gtk-3.0/qubes-incoming-bookmark-created ]
+then
+  echo "file:///home/user/QubesIncoming" >> ~/.config/gtk-3.0/bookmarks
+  touch ~/.config/gtk-3.0/qubes-incoming-bookmark-created
+fi

--- a/qubes-rpc/qubes.Filecopy
+++ b/qubes-rpc/qubes.Filecopy
@@ -1,2 +1,6 @@
 #!/bin/sh
+if [ -f /usr/lib/qubes/qvm_nautilus_bookmark.sh ]
+then
+  /usr/lib/qubes/qvm_nautilus_bookmark.sh >/dev/null 2>&1 </dev/null
+fi
 exec /usr/lib/qubes/qfile-unpacker

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -686,6 +686,7 @@ rm -f %{name}-%{version}
 /usr/share/nautilus-python/extensions/qvm_copy_nautilus.py*
 /usr/share/nautilus-python/extensions/qvm_move_nautilus.py*
 /usr/share/nautilus-python/extensions/qvm_dvm_nautilus.py*
+/usr/lib/qubes/qvm_nautilus_bookmark.sh
 
 %files thunar
 /usr/lib/qubes/qvm-actions.sh


### PR DESCRIPTION
A small script will add the QubesIncoming shortcut to Nautilus file pane
on the first use of qvm-copy to a given VM. The shortcut will not be recreated if
deleted.

fixes QubesOS/qubes-issues#2229