### PR TITLE
firewall: drop INVALID state TCP packets

### DIFF
--- a/network/ip6tables-enabled
+++ b/network/ip6tables-enabled
@@ -23,6 +23,7 @@ COMMIT
 :FORWARD DROP [0:0]
 :OUTPUT ACCEPT [0:0]
 :QBS-FORWARD - [0:0]
+-A INPUT -m state --state INVALID -j DROP
 -A INPUT -i lo -j ACCEPT
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -i vif+ -p icmpv6 --icmpv6-type router-advertisement -j DROP
@@ -31,6 +32,7 @@ COMMIT
 -A INPUT -i vif+ -j REJECT --reject-with icmp6-adm-prohibited
 -A INPUT -p icmpv6 -j ACCEPT
 -A INPUT -j DROP
+-A FORWARD -m state --state INVALID -j DROP
 -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -j QBS-FORWARD
 -A FORWARD -i vif+ -o vif+ -j DROP

--- a/network/iptables
+++ b/network/iptables
@@ -26,12 +26,14 @@ COMMIT
 :FORWARD DROP [0:0]
 :OUTPUT ACCEPT [0:0]
 :QBS-FORWARD - [0:0]
+-A INPUT -m state --state INVALID -j DROP
 -A INPUT -i vif+ -p udp -m udp --dport 68 -j DROP
 -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A INPUT -i vif+ -p icmp -j ACCEPT
 -A INPUT -i lo -j ACCEPT
 -A INPUT -i vif+ -j REJECT --reject-with icmp-host-prohibited
 -A INPUT -j DROP
+-A FORWARD -m state --state INVALID -j DROP
 -A FORWARD -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A FORWARD -j QBS-FORWARD
 -A FORWARD -i vif+ -o vif+ -j DROP


### PR DESCRIPTION
Packets detected as INVALID are ignored by NAT, so if they are not
dropped, packets with internal source IPs can leak to the outside
network.

See:

https://bugzilla.netfilter.org/show_bug.cgi?id=693
http://www.smythies.com/~doug/network/iptables_notes/

Fixes QubesOS/qubes-issues#5596.