### PR TITLE
Do not reference sudo group when removing Debian package

### DIFF
--- a/debian/qubes-core-agent-passwordless-root.postrm
+++ b/debian/qubes-core-agent-passwordless-root.postrm
@@ -37,7 +37,6 @@ set -e
 # the debian-policy package
 
 if [ "${1}" = "remove" ] ; then
-    gpasswd --delete user sudo
     if [ "$(passwd -S root|cut -f 2 -d ' ')" = "NP" ]; then
         passwd --lock root
     fi


### PR DESCRIPTION
The Package  includes an attempt to remove user from sudo group on removal, but the user is *not* a member of that group.
Remove reference in post-removal instructions.
Closes  QubesOS/qubes-issues#5469