### PR TITLE
Disable package caching in apt operations

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -1,5 +1,6 @@
 etc/apt/apt.conf.d/00notify-hook
 etc/apt/apt.conf.d/70no-unattended
+etc/apt/apt.conf.d/10no-cache
 etc/apt/sources.list.d/qubes-r4.list
 etc/apt/trusted.gpg.d/qubes-archive-keyring.gpg
 etc/dconf/db/local.d/dpi

--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -30,6 +30,8 @@ install-apt:
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/00notify-hook
 	install -D -m 0644 apt-conf-70no-unattended \
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/70no-unattended
+	install -D -m 0644 apt-conf-10no-cache \
+		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/10no-cache
 
 install-dnf: install-rpm
 	install -D -m 0644 dnf-qubes-hooks.py \

--- a/package-managers/apt-conf-10no-cache
+++ b/package-managers/apt-conf-10no-cache
@@ -1,0 +1,3 @@
+## Disable caching of packages in all apt operations
+
+APT::Keep-Downloaded-Packages "0";


### PR DESCRIPTION
Closes QubesOS/qubes-issues#5266