### PR TITLE
init: skip journal creation in DispVMs

### DIFF
--- a/init/functions
+++ b/init/functions
@@ -66,7 +66,7 @@ is_templatevm() {
 }
 
 is_dispvm() {
-    [ "$(qubes_vm_type)" = "DisposableVM" ]
+    [ "$(qubesdb-read /type)" = "DispVM" ]
 }
 
 is_fully_persistent() {


### PR DESCRIPTION
This reduces writes and improves speed on HDDs. On my machine, this change shrinks the size of a freshly created DispVM (at time of "disp9999 has started" notification) from ~97MiB to ~16MiB.

Additionally, this fixes is_dispvm(), which was previously unused but would report that a DispVM is an AppVM.