### PR TITLE
Added a qubes-open-file-manager.desktop file

### DIFF
--- a/app-menu/Makefile
+++ b/app-menu/Makefile
@@ -17,3 +17,4 @@ install:
 		qubes-session-autostart
 	install -d $(DESTDIR)/$(APPLICATIONSDIR)
 	install -t $(DESTDIR)/$(APPLICATIONSDIR) -m 0644 qubes-run-terminal.desktop
+	install -t $(DESTDIR)/$(APPLICATIONSDIR) -m 0644 qubes-open-file-manager.desktop

--- a/app-menu/qubes-open-file-manager.desktop
+++ b/app-menu/qubes-open-file-manager.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Run Terminal
+Exec=xdg-open $HOME
+Icon=system-file-manager
+Type=Application

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -689,6 +689,7 @@ rm -f %{name}-%{version}
 %dir /usr/lib/qubes-bind-dirs.d
 /usr/lib/qubes-bind-dirs.d/30_cron.conf
 /usr/share/applications/qubes-run-terminal.desktop
+/usr/share/applications/qubes-open-file-manager.desktop
 /usr/share/qubes/serial.conf
 /usr/share/qubes/marker-vm
 /usr/share/glib-2.0/schemas/20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override


### PR DESCRIPTION
To be used by GUI tools to provide a convenient 'open file manager' shortcut.

references QubesOS/qubes-issues#5170