### PR TITLE
fixed qubes.GetAppmenus ignoring some correct .desktop files

### DIFF
--- a/qubes-rpc/qubes.GetAppmenus
+++ b/qubes-rpc/qubes.GetAppmenus
@@ -60,7 +60,7 @@ find "${apps_dirs[@]}" -name '*.desktop' -print0 2>/dev/null | \
          xargs -0 awk '
          BEGINFILE { if (ERRNO) nextfile; entry="" }
          /^\[/ { if (tolower($0) != "\[desktop entry\]") nextfile } 
-         /^Exec=/ { entry = entry FILENAME ":Exec=qubes-desktop-run " FILENAME "\n"; next }
+         /^Exec *=/ { entry = entry FILENAME ":Exec=qubes-desktop-run " FILENAME "\n"; next }
          /^NoDisplay *= *true$/ { entry=""; nextfile }
          /=/ { entry = entry FILENAME ":" $0 "\n" }
          ENDFILE { print entry }


### PR DESCRIPTION
.desktop files can have spaces around '=' symbols; previously
GetAppmenus discarded such files.

references QubesOS/qubes-issues#5692