### PR TITLE
Fix dependencies for Ubuntu 20.04 LTS (Focal Fossa)

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+qubes-core-agent (4.1.14-1ubuntu1) UNRELEASED; urgency=medium
+
+  * debian/control: initscripts dependency set to initscripts | sysvinit-utils
+    to fix FTBFS on Ubuntu 20.04 LTS (Focal Fossa).
+
+ -- Krzysztof Burghardt <krzysztof@burghardt.pl>  Mon, 20 Jul 2020 23:03:18 +0200
+
 qubes-core-agent (4.1.14-1) unstable; urgency=medium
 
   [ Marek Marczykowski-Górecki ]

--- a/debian/control
+++ b/debian/control
@@ -31,7 +31,7 @@ Depends:
     gawk,
     imagemagick,
     init-system-helpers,
-    initscripts,
+    initscripts | sysvinit-utils,
     librsvg2-bin,
     locales,
     ncurses-term,


### PR DESCRIPTION
This is the only issue preventing focal build of core agent and in turn vm template construction.