### PR TITLE
Fix home path in qubes-open-file-manager.desktop

### DIFF
--- a/app-menu/qubes-open-file-manager.desktop
+++ b/app-menu/qubes-open-file-manager.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
 Name=Run Terminal
-Exec=xdg-open $HOME
+Exec=xdg-open .
 Icon=system-file-manager
 Type=Application


### PR DESCRIPTION
Looks like desktop entries doesn`t allow environment variables in Exec string.

>qubes.StartApp+qubes-open-file-manager-dom0[1782]: gio: file:///home/user/$HOME: Error when getting information for file “/home/user/$HOME”: No such file or directory

switching to '.' resolve it.