### PR TITLE
PolicyKit: only grant passwordless access to group qubes

### DIFF
--- a/passwordless-root/polkit-1-qubes-allow-all.pkla
+++ b/passwordless-root/polkit-1-qubes-allow-all.pkla
@@ -1,5 +1,5 @@
 [Qubes allow all]
-Identity=*
+Identity=unix-group:qubes
 Action=*
 ResultAny=yes
 ResultInactive=yes

--- a/passwordless-root/qubes.sudoers
+++ b/passwordless-root/qubes.sudoers
@@ -1,5 +1,5 @@
 Defaults !requiretty
-user ALL=(ALL) NOPASSWD: ALL
+%qubes ALL=(ALL) NOPASSWD: ALL
 
 # WTF?! Have you lost your mind?!
 #


### PR DESCRIPTION
Without this restriction system users can start processes with root privileges:

```
$ sudo -u mail systemd-run --pipe -q id
uid=0(root) gid=0(root) groups=0(root)
```

This change restrict passwordless access to group qubes bringing it in line with `sudo` and `su`.

I also changed the sudoers file to allow group `qubes` rather than user `user`. This change is merely for consistency. Before `sudo` was restricted based on user and `su` based on group.