### PR TITLE
Order swap before systemd-fsck-root.service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ install-init:
 	install -m 0644 init/functions $(DESTDIR)$(LIBDIR)/qubes/init/
 
 # Systemd service files
-SYSTEMD_ALL_SERVICES := $(wildcard vm-systemd/qubes-*.service)
+SYSTEMD_ALL_SERVICES := $(wildcard vm-systemd/qubes-*.service) vm-systemd/dev-xvdc1-swap.service
 SYSTEMD_NETWORK_SERVICES := vm-systemd/qubes-firewall.service vm-systemd/qubes-iptables.service vm-systemd/qubes-updates-proxy.service
 SYSTEMD_CORE_SERVICES := $(filter-out $(SYSTEMD_NETWORK_SERVICES), $(SYSTEMD_ALL_SERVICES))
 

--- a/boot/grub.qubes
+++ b/boot/grub.qubes
@@ -1,5 +1,6 @@
 # make sure to use /dev/mapper/dmroot, not /dev/xvda directly - both have the
 # same fs, including UUID
+GRUB_DEVICE=/dev/mapper/dmroot
 GRUB_DISABLE_LINUX_UUID=true
 GRUB_DISABLE_OS_PROBER=true
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX root=/dev/mapper/dmroot console=tty0 console=hvc0"

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -83,6 +83,7 @@ lib/systemd/system/netfilter-persistent.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.path.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.socket.d/30_qubes.conf
+lib/systemd/system/dev-xvdc1-swap.service
 lib/systemd/system/qubes-early-vm-config.service
 lib/systemd/system/qubes-misc-post.service
 lib/systemd/system/qubes-mount-dirs.service

--- a/init/setup-rwdev.sh
+++ b/init/setup-rwdev.sh
@@ -7,7 +7,7 @@
 set -e
 
 dev=/dev/xvdb
-max_size=1073741824  # check at most 1 GiB
+max_size=10485760  # check at most 10 MiB
 
 if [ -e "$dev" ] ; then
     # The private /dev/xvdb device is present.

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -908,6 +908,7 @@ The Qubes core startup configuration for SystemD init.
 %files systemd
 %defattr(-,root,root,-)
 /etc/systemd/system/xendriverdomain.service
+/lib/systemd/system/dev-xvdc1-swap.service
 /lib/systemd/system/qubes-misc-post.service
 /lib/systemd/system/qubes-mount-dirs.service
 /lib/systemd/system/qubes-rootfs-resize.service

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -107,6 +107,7 @@ enable qubes-sync-time.timer
 enable module-load-dummy-psu.service
 enable module-load-dummy-backlight.service
 enable qubes-psu-client@.service default sys-usb
+enable dev-xvdc1-swap.service
 
 # Disable useless Xen services in Qubes VM
 disable xenstored.service

--- a/vm-systemd/dev-xvdc1-swap.service
+++ b/vm-systemd/dev-xvdc1-swap.service
@@ -1,0 +1,13 @@
+[Unit]
+# have it as  .service, not .swap, because .swap has implicit dependency on
+# .device which needs udev running already
+Description=Enable swap on /dev/xvdc1 early
+DefaultDependencies=no
+Before=systemd-fsck-root.service
+
+[Service]
+Type=oneshot
+ExecStart=-/usr/sbin/swapon /dev/xvdc1
+
+[Install]
+WantedBy=sysinit.target

--- a/vm-systemd/qubes-sysinit.sh
+++ b/vm-systemd/qubes-sysinit.sh
@@ -11,11 +11,6 @@ DEFAULT_ENABLED_APPVM="cups qubes-update-check meminfo-writer"
 DEFAULT_ENABLED_TEMPLATEVM="$DEFAULT_ENABLED_APPVM updates-proxy-setup"
 DEFAULT_ENABLED="meminfo-writer"
 
-if systemd_version_changed ; then
-    # Ensure we're running right version of systemd (the one started by initrd may be different)
-    systemctl daemon-reexec
-fi
-
 # Wait for xenbus initialization
 while [ ! -e /dev/xen/xenbus ]; do
   sleep 0.1

--- a/vm-systemd/systemd-fsck-root.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-fsck-root.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+After=swap.target


### PR DESCRIPTION
When the fsck is run in the target system, make sure it is started after
enabling swap. In recent Fedora versions, it can also run in initramfs - that
part will be handled in dracut module (linux-utils repository). Here just
ensure the root= parameter is properly set in grub (in case of in-VM kernel use).

Fixes QubesOS/qubes-issues#6174