### PR TITLE
Replace custom script reloading with sourcing /etc/profile

### DIFF
--- a/qubes-rpc/qubes.GetAppmenus
+++ b/qubes-rpc/qubes.GetAppmenus
@@ -9,12 +9,8 @@
 # Reload scripts in /etc/profile.d/, in case they register additional
 # directories in XDG_DATA_DIRS and we forgot them
 # (e.g. because we are running under sudo).
-for i in /etc/profile.d/*.sh ; do
-    if [ -r "$i" ]; then
-        # shellcheck disable=SC1090
-        . "$i" >/dev/null
-    fi
-done
+# shellcheck disable=SC1091
+source /etc/profile
 
 if [ -z "$XDG_DATA_HOME" ]; then
     user="$(whoami)"


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/6163

This PR replaces custom reloading of /etc/profile.d scripts with /etc/profile, which may load additional vars/functions that are needed by the scripts in /etc/profile.d