### PR TITLE
Only allow known-safe characters in socket paths

### DIFF
--- a/qubes-rpc/qubes.ShowInTerminal
+++ b/qubes-rpc/qubes.ShowInTerminal
@@ -1,10 +1,11 @@
 #!/bin/bash --
 
 set -eu
+umask 0077
 tmpdir="$(mktemp -d)"
 
-if [[ $tmpdir =~ \" ]]; then
-    echo 'Error: non admissible character detected in sock path.'
+if ! [[ $tmpdir =~ ^/[/A-Za-z0-9._-]+$ ]]; then
+    echo 'Error: non admissible character detected in sock path.'>&2
     exit 1
 fi
 


### PR DESCRIPTION
The socket path will be included in a shell command and then as a socat
argument, so only allow a small subset of known-safe characters.  In
practice, this has not been a problem because mktemp doesn’t include
these characters in its output.