### PR TITLE
Issue #6239

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -61,7 +61,7 @@ package_qubes-vm-core() {
              gnome-packagekit imagemagick fakeroot notification-daemon dconf
              zenity qubes-libvchan qubes-db-vm haveged python-gobject
              python-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg
-             socat
+             socat pacman-contrib
              )
     optdepends=(gnome-keyring gnome-settings-daemon python-nautilus gpk-update-viewer qubes-vm-networking qubes-vm-keyring)
     install=PKGBUILD.install

--- a/package-managers/upgrades-installed-check
+++ b/package-managers/upgrades-installed-check
@@ -34,7 +34,8 @@ elif [ -e /etc/arch-release ]; then
     set -o pipefail
     checkupdates_output="$(checkupdates 2>&1)"
     exit_code="$?"
-    echo "$checkupdates_output" | grep -qF -- '->' && echo "false" || echo "true"
+    [ "$exit_code" -eq 2 ] && echo "true" && exit 0
+    echo "false"
 elif [ -e /etc/gentoo-release ]; then
     ## Gentoo
     set -e

--- a/qubes-rpc/qubes.InstallUpdatesGUI
+++ b/qubes-rpc/qubes.InstallUpdatesGUI
@@ -20,4 +20,8 @@ fi
 xterm -title update -e su -s /bin/sh -l -c "$update_cmd; echo Done.; test -f /var/run/qubes/this-is-templatevm && { echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff; } ;"
 
 # Notify dom0 about installed updates
-su -s /bin/sh -c 'service qubes-update-check start'
+if [ -e /etc/arch-release ]; then
+    su -s /bin/sh -c 'systemctl start qubes-update-check'
+else
+    su -s /bin/sh -c 'service qubes-update-check start'
+fi


### PR DESCRIPTION
Partial fix QubesOS/qubes-issues#6239

- [x] fix the upgrades-installed-check script (checkupdate result analysis)
- [X] add the pacman-contrib dependency for qubes-vm-core

The remaining part is
- [ ] fix the qubes.InstallUpdatesGUI qubes-rpc (service launching)
but as @DemiMarie reported «The Qubes updater uses SaltStack to update VMs, not qubes.InstallUpdatesGUI». But I don't know yet how Salt is working.
_For information_, below my change of qubes.InstallUpdatesGUI:
```
diff --git a/qubes-rpc/qubes.InstallUpdatesGUI b/qubes-rpc/qubes.InstallUpdatesGUI
index e01bace..952148b 100755
--- a/qubes-rpc/qubes.InstallUpdatesGUI
+++ b/qubes-rpc/qubes.InstallUpdatesGUI
@@ -20,4 +20,8 @@ fi
 xterm -title update -e su -s /bin/sh -l -c "$update_cmd; echo Done.; test -f /var/run/qubes/this-is-templatevm && { echo Press Enter to shutdown the template, or Ctrl-C to just close this window; read x && poweroff; } ;"
 
 # Notify dom0 about installed updates
-su -s /bin/sh -c 'service qubes-update-check start'
+if [ -e /etc/arch-release ]; then
+    su -s /bin/sh -c 'systemctl start qubes-update-check'
+else
+    su -s /bin/sh -c 'service qubes-update-check start'
+fi
```
Explanation: ArchLinux doesn't use the service command.
