### PR TITLE
Allow SELinux to stay enabled

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -492,10 +492,15 @@ fi
 exit 0
 
 %triggerin -- selinux-policy
-#echo "--> Disabling SELinux..."
-sed -e s/^SELINUX=.*$/SELINUX=disabled/ </etc/selinux/config >/etc/selinux/config.processed
-mv /etc/selinux/config.processed /etc/selinux/config
-setenforce 0 2>/dev/null
+
+. /usr/lib/qubes/init/functions
+
+if ! is_protected_file /etc/selinux/config; then
+    echo "--> Disabling SELinux..."
+    sed -e s/^SELINUX=.*$/SELINUX=disabled/ </etc/selinux/config >/etc/selinux/config.processed
+    mv /etc/selinux/config.processed /etc/selinux/config
+    setenforce 0 2>/dev/null
+fi
 exit 0
 
 %post network-manager


### PR DESCRIPTION
Users who have their own SELinux policies should be able to keep QubesOS
from disabling SELinux.