### PR TITLE
network: fix waiting for VM network uplink

### DIFF
--- a/init/functions
+++ b/init/functions
@@ -138,6 +138,12 @@ get_qubes_managed_iface() {
     local mac
     local qubes_iface
     mac="$(qubesdb-read /qubes-mac 2> /dev/null)"
+    if [ -z "$mac" ]; then
+        # no qubes-managed network interface
+        return
+    fi
+    # Load the module explicitly here, to avoid waiting for udev doing that
+    [ -e /sys/module/xen_netfront ] || modprobe xen-netfront || :
     qubes_iface="$(get_iface_from_mac "$mac")"
     if [ "x$qubes_iface" != "x" ]; then
         echo "$qubes_iface"

--- a/package-managers/upgrades-installed-check
+++ b/package-managers/upgrades-installed-check
@@ -15,7 +15,7 @@ if [ -e /etc/system-release ]; then
         yum=yum
     fi
     # shellcheck disable=SC2034
-    yum_output="$($yum -yq check-update 2>&1)"
+    yum_output="$($yum -yq check-update)"
     exit_code="$?"
     [ "$exit_code" -eq 100 ] && echo "false" && exit 0
     [ "$exit_code" -eq 0 ] && echo "true"

--- a/package-managers/upgrades-status-notify
+++ b/package-managers/upgrades-status-notify
@@ -2,7 +2,7 @@
 
 set -e
 
-upgrades_installed="$(/usr/lib/qubes/upgrades-installed-check 2>&1)"
+upgrades_installed="$(/usr/lib/qubes/upgrades-installed-check)"
 
 if [ "$upgrades_installed" = "true" ]; then
     /usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0'


### PR DESCRIPTION
The network-uplink-wait.sh script may be called before xen-netfront
module is even loaded (by udev). In that case, `get_qubes_managed_iface`
will fail to get the interface name and the wait will be skipped.

Fix this by loading xen-netfront module explicitly (do not try to
synchronize with udev, which is tricky not knowing the device
name).