### PR TITLE
Always pass ‘-y’ to dnf

### DIFF
--- a/package-managers/upgrades-installed-check
+++ b/package-managers/upgrades-installed-check
@@ -15,7 +15,7 @@ if [ -e /etc/system-release ]; then
         yum=yum
     fi
     # shellcheck disable=SC2034
-    yum_output="$($yum -q check-update 2>&1)"
+    yum_output="$($yum -yq check-update 2>&1)"
     exit_code="$?"
     [ "$exit_code" -eq 100 ] && echo "false" && exit 0
     [ "$exit_code" -eq 0 ] && echo "true"


### PR DESCRIPTION
DNF should never be used unattended without ‘-y’.