### PR TITLE
Turn off middle mouse paste in gnome-terminal

### DIFF
--- a/config-overrides/Makefile
+++ b/config-overrides/Makefile
@@ -12,6 +12,7 @@ install:
 	install -D -m 0440 sudoers.d_umask $(DESTDIR)$(SUDOERSDIR)/umask
 	install -D -m 0644 20_tcp_timestamps.conf $(DESTDIR)$(SYSCONFDIR)/sysctl.d/20_tcp_timestamps.conf
 	install -D -m 0644 dconf-db-local-dpi $(DESTDIR)$(SYSCONFDIR)/dconf/db/local.d/dpi
+	install -D -m 0644 dconf-db-local-middle-mouse-paste $(DESTDIR)$(SYSCONFDIR)/dconf/db/local.d/middle-mouse-paste
 	install -d $(DESTDIR)$(GLIBSCHEMAS)
 	install -t $(DESTDIR)$(GLIBSCHEMAS) -m 0644 \
 		20_org.gnome.desktop.wm.preferences.qubes.gschema.override \

--- a/config-overrides/dconf-db-local-middle-mouse-paste
+++ b/config-overrides/dconf-db-local-middle-mouse-paste
@@ -1,0 +1,2 @@
+[org/gnome/desktop/interface]
+gtk-enable-primary-paste=false

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -4,6 +4,7 @@ etc/apt/apt.conf.d/10no-cache
 etc/apt/sources.list.d/qubes-r4.list
 etc/apt/trusted.gpg.d/qubes-archive-keyring.gpg
 etc/dconf/db/local.d/dpi
+etc/dconf/db/local.d/middle-mouse-paste
 etc/default/grub.d/30-qubes.cfg
 etc/fstab
 etc/needrestart/conf.d/50_qubes.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -674,6 +674,7 @@ rm -f %{name}-%{version}
 %endif
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
 %config(noreplace) /etc/dconf/db/local.d/dpi
+%config(noreplace) /etc/dconf/db/local.d/middle-mouse-paste
 /lib/udev/rules.d/50-qubes-mem-hotplug.rules
 /usr/lib/systemd/system/user@.service.d/90-session-stop-timeout.conf
 /usr/sbin/qubes-serial-login


### PR DESCRIPTION
It is *very* easy to trigger this by accident, and this can easily
result in system compromise if one is not careful.