### PR TITLE
Use 022 instead of 002 as sudo umask

### DIFF
--- a/config-overrides/sudoers.d_umask
+++ b/config-overrides/sudoers.d_umask
@@ -1,3 +1,3 @@
 # Sudo's defualt umask is 077 so set sane default of 022
-Defaults umask = 0002
+Defaults umask = 0022
 Defaults umask_override


### PR DESCRIPTION
The comment already mentions 022, which is presumably what was intended.