### PR TITLE
Avoid deprecated /var/run directory

### DIFF
--- a/vm-systemd/qubes-core-agent-linux.tmpfiles
+++ b/vm-systemd/qubes-core-agent-linux.tmpfiles
@@ -1,1 +1,1 @@
-d /var/run/tinyproxy-updates 0755 tinyproxy tinyproxy
+d /run/tinyproxy-updates 0755 tinyproxy tinyproxy


### PR DESCRIPTION
It causes systemd to emit warnings.