### PR TITLE
Handle UnicodeError in firewall when resolving hostname

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -619,6 +619,9 @@ class NftablesWorker(FirewallWorker):
                 except socket.gaierror as e:
                     raise RuleParseError('Failed to resolve {}: {}'.format(
                         rule['dsthost'], str(e)))
+                except UnicodeError as e:
+                    raise RuleParseError('Invalid destination {}: {}'.format(
+                        rule['dsthost'], str(e)))
                 nft_rule += ' {} daddr {{ {} }}'.format(ip_match,
                     ', '.join(set(item[4][0] + fullmask for item in addrinfo)))
 


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#6290 as a last resort in the event a domain part is too long (>64 chars) or empty (eg `host..name.com`).

Behavior is same as a DNS resolution failure: block all traffic.