### PR TITLE
archlinux: pin PKGBUILD to python3.X major version as new python vers…

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,5 +1,3 @@
-#!/bin/bash
-# shellcheck disable=SC2034
 pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring)
 pkgver=$(cat version)
 pkgrel=15
@@ -64,6 +62,8 @@ package_qubes-vm-core() {
              zenity qubes-libvchan qubes-db-vm haveged python-gobject
              python-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg
              socat
+            # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
+            'python<3.10'
              )
     optdepends=(gnome-keyring gnome-settings-daemon python-nautilus gpk-update-viewer qubes-vm-networking qubes-vm-keyring)
     install=PKGBUILD.install


### PR DESCRIPTION
…ion will break the API.

Should also be applied to branch 4.1 if possible to cherry-pick.