### PR TITLE
qubes-early-vm-config.service: Wants=network-pre.target

### DIFF
--- a/vm-systemd/qubes-early-vm-config.service
+++ b/vm-systemd/qubes-early-vm-config.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Early Qubes VM settings
 DefaultDependencies=no
+Wants=network-pre.target
 Before=sysinit.target network-pre.target
 After=local-fs.target qubes-db.service
 


### PR DESCRIPTION
The unit on the Before= side of network-pre.target also has to pull it
in as a dependency:

https://www.freedesktop.org/software/systemd/man/systemd.special.html#network-pre.target

Fixes QubesOS/qubes-issues#5570