### PR TITLE
rpm: order -systemd post script after -networking

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -914,6 +914,8 @@ Conflicts:      qubes-core-agent-sysvinit
 Provides:       qubes-core-vm-systemd = %{version}-%{release}
 Obsoletes:      qubes-core-vm-systemd < 4.0.0
 Conflicts:      qubes-gui-agent < 4.1.0
+# preset units after possibly new are installed
+OrderWithRequires(post): qubes-core-agent-networking
 
 %description systemd
 The Qubes core startup configuration for SystemD init.


### PR DESCRIPTION
qubes-core-agent-networking package brings in new systemd units, which
needs to be enabled. Standard %systemd_post macro handles it only on
initial installation, but not on update. The function that handle
updates is in %post of qubes-core-agent-systemd package. To avoid
duplication, simply enforce proper installation order, instead of
modifying %post of qubes-core-agent-networking package.

OrderWithRequires influences only ordering, but does not introduce
actual dependency, so it's still possible to not install
qubes-core-agent-networking package.

Fixes 0e0c229 "rpm: enable qubes-network-uplink.service on install"