### PR TITLE
network: enable MAC randomization for wifi connections by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,6 +188,7 @@ install-networkmanager:
 
 	install -d $(DESTDIR)/usr/lib/NetworkManager/conf.d
 	install -m 0644 network/nm-30-qubes.conf $(DESTDIR)/usr/lib/NetworkManager/conf.d/30-qubes.conf
+	install -m 0644 network/nm-31-randomize-mac.conf $(DESTDIR)/usr/lib/NetworkManager/conf.d/31-randomize-mac.conf
 
 	install -d $(DESTDIR)/etc/xdg/autostart
 	install -m 0755 network/show-hide-nm-applet.sh $(DESTDIR)$(LIBDIR)/qubes/

--- a/debian/qubes-core-agent-network-manager.install
+++ b/debian/qubes-core-agent-network-manager.install
@@ -2,6 +2,7 @@ etc/NetworkManager/dispatcher.d/30-qubes-external-ip
 etc/NetworkManager/dispatcher.d/qubes-nmhook
 etc/xdg/autostart/00-qubes-show-hide-nm-applet.desktop
 usr/lib/NetworkManager/conf.d/30-qubes.conf
+usr/lib/NetworkManager/conf.d/31-randomize-mac.conf
 usr/lib/qubes/network-manager-prepare-conf-dir
 usr/lib/qubes/qubes-fix-nm-conf.sh
 usr/lib/qubes/show-hide-nm-applet.sh

--- a/network/nm-31-randomize-mac.conf
+++ b/network/nm-31-randomize-mac.conf
@@ -1,0 +1,6 @@
+[device]
+wifi.scan-rand-mac-address=yes
+
+[connection]
+wifi.cloned-mac-address=stable
+connection.stable-id=${CONNECTION}/${BOOT}

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -822,6 +822,7 @@ rm -f %{name}-%{version}
 /etc/NetworkManager/dispatcher.d/qubes-nmhook
 /etc/xdg/autostart/00-qubes-show-hide-nm-applet.desktop
 /usr/lib/NetworkManager/conf.d/30-qubes.conf
+/usr/lib/NetworkManager/conf.d/31-randomize-mac.conf
 /usr/lib/qubes/network-manager-prepare-conf-dir
 /usr/lib/qubes/qubes-fix-nm-conf.sh
 /usr/lib/qubes/show-hide-nm-applet.sh


### PR DESCRIPTION
We do have NetworkManager new enough to handle this feature already.
Enable both scan MAC address randomization, and also connection mac
address randomization. The later do in a "stable" way - preserving the
same MAC _for a connection_, until reboot. This is a safe tradeoff
between full random, which breaks some captive portals. The stable MAC
is generated separate for each connection, so it also prevents
correlation of the same machine between different networks.

Do not enable it for wired connections, as those are less often used at
random untrusted localizations, but also more often it's desired to
get the same IP address each time (having random MAC would make it much
harder).

QubesOS/qubes-issues#938