### PR TITLE
fix #6562: make sure that xdg-open as called by qubes-open have an empty stdout

### DIFF
--- a/qubes-rpc/qubes-open
+++ b/qubes-rpc/qubes-open
@@ -9,4 +9,4 @@ fi
 # closed, which is critical behaviour for DisposableVM (which gets destroyed
 # after this process exits)
 export DE=generic
-exec xdg-open "$@"
+exec xdg-open "$@" >&2


### PR DESCRIPTION
should fix https://github.com/QubesOS/qubes-issues/issues/6562. 
The assumption that I made is that there is no case where "qubes-open" need to have a non-empty stdout.

(At least, tested if against my firefox issue, and it work as expected. But didn't ran more extensive tests)