### PR TITLE
Add to man page that qvm-open-in-dvm can handle a URL -  Update qvm-open-in-dvm.rst

### DIFF
--- a/doc/vm-tools/qvm-open-in-dvm.rst
+++ b/doc/vm-tools/qvm-open-in-dvm.rst
@@ -4,11 +4,12 @@ qvm-open-in-dvm
 
 NAME
 ====
-qvm-open-in-dvm - open a specified file in disposable VM
+qvm-open-in-dvm - open a specified file or URL in a disposable VM
 
 SYNOPSIS
 ========
 | qvm-open-in-dvm filename
+| qvm-open-in-dvm URL
 
 OPTIONS
 =======


### PR DESCRIPTION
Intended behavior is for qvm-open-in-dvm to be able to handle URLs or filenames, but the man page made no reference of URLS. Updated the documentation to reflect that.

