### PR TITLE
Export DNS information obtained during firewall setup to QubesDB

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -169,12 +169,12 @@ class FirewallWorker(object):
         User applications may watch these paths for count increases to remain
         up to date with QubesDB changes.
         """
-        cnt = self.qdb.read('/qubes-firewall_handled/{}'.format(addr))
+        cnt = self.qdb.read('/qubes-firewall-handled/{}'.format(addr))
         try:
             cnt = int(cnt)
         except (TypeError, ValueError):
             cnt = 0
-        self.qdb.write('/qubes-firewall_handled/{}'.format(addr), str(cnt+1))
+        self.qdb.write('/qubes-firewall-handled/{}'.format(addr), str(cnt+1))
 
     def list_targets(self):
         return set(t.split('/')[2] for t in self.qdb.list('/qubes-firewall/'))

--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -211,14 +211,14 @@ class FirewallWorker(object):
         self.run_firewall_dir()
         self.run_user_script()
         self.sd_notify('READY=1')
+        self.qdb.watch('/qubes-firewall/')
+        self.qdb.watch('/connected-ips')
+        self.qdb.watch('/connected-ips6')
         # initial load
         for source_addr in self.list_targets():
             self.handle_addr(source_addr)
         self.update_connected_ips(4)
         self.update_connected_ips(6)
-        self.qdb.watch('/qubes-firewall/')
-        self.qdb.watch('/connected-ips')
-        self.qdb.watch('/connected-ips6')
         try:
             for watch_path in iter(self.qdb.read_watch, None):
                 if watch_path == '/connected-ips':

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -685,17 +685,17 @@ class TestFirewallWorker(TestCase):
     def test_handle_addr(self):
         self.obj.handle_addr('10.137.0.2')
         self.assertEqual(self.obj.rules['10.137.0.2'], [{'action': 'accept'}])
-        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.2'], '1')
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall-handled/10.137.0.2'], '1')
         self.obj.handle_addr('10.137.0.2')
         self.assertEqual(self.obj.rules['10.137.0.2'], [{'action': 'accept'}])
-        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.2'], '2')
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall-handled/10.137.0.2'], '2')
         # fallback to block all
         self.obj.handle_addr('10.137.0.3')
         self.assertEqual(self.obj.rules['10.137.0.3'], [{'action': 'drop'}])
-        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.3'], '1')
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall-handled/10.137.0.3'], '1')
         self.obj.handle_addr('10.137.0.4')
         self.assertEqual(self.obj.rules['10.137.0.4'], [{'action': 'drop'}])
-        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.4'], '1')
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall-handled/10.137.0.4'], '1')
 
     @patch('os.path.isfile')
     @patch('os.access')

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -675,11 +675,17 @@ class TestFirewallWorker(TestCase):
     def test_handle_addr(self):
         self.obj.handle_addr('10.137.0.2')
         self.assertEqual(self.obj.rules['10.137.0.2'], [{'action': 'accept'}])
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.2'], '1')
+        self.obj.handle_addr('10.137.0.2')
+        self.assertEqual(self.obj.rules['10.137.0.2'], [{'action': 'accept'}])
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.2'], '2')
         # fallback to block all
         self.obj.handle_addr('10.137.0.3')
         self.assertEqual(self.obj.rules['10.137.0.3'], [{'action': 'drop'}])
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.3'], '1')
         self.obj.handle_addr('10.137.0.4')
         self.assertEqual(self.obj.rules['10.137.0.4'], [{'action': 'drop'}])
+        self.assertEqual(self.obj.qdb.entries['/qubes-firewall_handled/10.137.0.4'], '1')
 
     @patch('os.path.isfile')
     @patch('os.access')

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -29,6 +29,14 @@ class DummyQubesDB(object):
         except KeyError:
             return None
 
+    def rm(self, path):
+        if path.endswith('/'):
+            for key in self.entries:
+                if key.startswith(path):
+                    self.entries.pop(key)
+        else:
+            self.entries.pop(path)
+
     def multiread(self, prefix):
         result = {}
         for key, value in self.entries.items():


### PR DESCRIPTION
This can e.g. allow DNS applications to pin a FQDN to the IP
used during Qubes OS firewall setup.

Can help with QubesOS/qubes-issues#5225 and other related issues.