### PR TITLE
fix #6562. qvm-open-in-vm: wait EOF when handling URL

### DIFF
--- a/qubes-rpc/qvm-open-in-vm
+++ b/qubes-rpc/qvm-open-in-vm
@@ -48,7 +48,7 @@ fi
 
 case "$filename" in
 	*://*)
-        exec /usr/lib/qubes/qrexec-client-vm "$target" qubes.OpenURL /bin/echo "$filename"
+        exec /usr/lib/qubes/qrexec-client-vm "$target" qubes.OpenURL /bin/sh -c 'printf "%s\n" "$0"; cat >/dev/null' "$filename"
         ;;
     *)
         exec /usr/lib/qubes/qrexec-client-vm "$target" qubes.OpenInVM "/usr/lib/qubes/qopen-in-vm" $qopen_opts "$filename"


### PR DESCRIPTION
should fix QubesOS/qubes-issues#6562.
The assumption that I made is that there is no case where we need to have a non-empty stdout when handling URL in qvm-open-in-vm.

(At least, tested if against my firefox issue, and it work as expected. But didn't ran more extensive tests)