### PR TITLE
Include official Qubes repositories

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -20,6 +20,7 @@ source=(
     PKGBUILD.qubes-ensure-lib-modules.service PKGBUILD.qubes-update-desktop-icons.hook
     PKGBUILD-qubes-pacman-options.conf
     PKGBUILD-qubes-repo-4.0.conf
+    PKGBUILD-qubes-testing-repo-4.0.conf
     PKGBUILD-keyring-keys
     PKGBUILD-keyring-trusted
     PKGBUILD-keyring-revoked
@@ -96,6 +97,7 @@ package_qubes-vm-core() {
     release=$(echo "$pkgver" | cut -d '.' -f 1,2)
     echo "Installing repository for release ${release}"
     install -m 644 "$srcdir/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
+    install -m 644 "$srcdir/PKGBUILD-qubes-testing-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-testing-repository-${release}.conf.disabled"
 
     # Archlinux specific: enable autologin on tty1
     mkdir -p "$pkgdir/etc/systemd/system/getty@tty1.service.d/"

--- a/archlinux/PKGBUILD-qubes-repo-4.0.conf
+++ b/archlinux/PKGBUILD-qubes-repo-4.0.conf
@@ -1,2 +1,2 @@
-[qubes-r4.0]
-#Server = https://YOUR_OWN_SERVER
+[qubes-r4.0-current]
+Server = https://archlinux.qubes-os.org/r4.0/current/vm/archlinux/pkgs

--- a/archlinux/PKGBUILD-qubes-testing-repo-4.0.conf
+++ b/archlinux/PKGBUILD-qubes-testing-repo-4.0.conf
@@ -1,0 +1,2 @@
+[qubes-r4.0-current-testing]
+Server = https://archlinux.qubes-os.org/r4.0/current-testing/vm/archlinux/pkgs/


### PR DESCRIPTION
Addresses QubesOS/qubes-issues#6610 by setting official repository definitions (at least for 4.0 - I'll check 4.1 later)