### PR TITLE
Add a "open in disposable VM" to desktop environment

### DIFF
--- a/app-menu/Makefile
+++ b/app-menu/Makefile
@@ -18,3 +18,4 @@ install:
 	install -d $(DESTDIR)/$(APPLICATIONSDIR)
 	install -t $(DESTDIR)/$(APPLICATIONSDIR) -m 0644 qubes-run-terminal.desktop
 	install -t $(DESTDIR)/$(APPLICATIONSDIR) -m 0644 qubes-open-file-manager.desktop
+	install -t $(DESTDIR)/$(APPLICATIONSDIR) -m 0644 qvm-open-in-dvm.desktop

--- a/app-menu/qvm-open-in-dvm.desktop
+++ b/app-menu/qvm-open-in-dvm.desktop
@@ -1,0 +1,10 @@
+### Note: With this installed, typing "xdg-settings set default-web-browser qvm-open-in-dvm.desktop" will make it so that in gnome-terminal
+###   that right clicking on a URL on screen, then selecting "open with" to open the link, will open it in a disposable VM (as opposed to opening it in the current VM)
+###   (typing "xdg-settings set default-web-browser firefox.desktop" will put it back to normal)
+
+[Desktop Entry]
+Name=qvm-open-in-dvm
+Exec=qvm-open-in-dvm %u
+Type=Application
+Categories=Network;WebBrowser;
+MimeType=x-scheme-handler/unknown;x-scheme-handler/about;text/html;text/xml;application/xhtml+xml;application/xml;application/vnd.mozilla.xul+xml;application/rss+xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;

--- a/doc/vm-tools/qvm-open-in-dvm.rst
+++ b/doc/vm-tools/qvm-open-in-dvm.rst
@@ -4,14 +4,25 @@ qvm-open-in-dvm
 
 NAME
 ====
-qvm-open-in-dvm - open a specified file in disposable VM
+qvm-open-in-dvm - open a specified file or URL in a disposable VM
 
 SYNOPSIS
 ========
 | qvm-open-in-dvm filename
+| qvm-open-in-dvm URL
 
 OPTIONS
 =======
+
+
+NOTES
+=====
+Typing "xdg-settings set default-web-browser qvm-open-in-dvm.desktop" will make it so that gnome-terminal can use this,
+to open a URL on the terminal screen in a disposable VM. 
+(by right clicking on a URL on the terminal screen, then selecting "open with" to open the link)
+
+Typing "xdg-settings set default-web-browser firefox.desktop" will put it back to default behavior
+
 
 AUTHORS
 =======

--- a/doc/vm-tools/qvm-open-in-vm.rst
+++ b/doc/vm-tools/qvm-open-in-vm.rst
@@ -4,11 +4,12 @@ qvm-open-in-vm
 
 NAME
 ====
-qvm-open-in-vm - open a specified file in other VM
+qvm-open-in-vm - open a specified file or URL in a other VM
 
 SYNOPSIS
 ========
 | qvm-open-in-vm vmname filename
+| qvm-open-in-vm vmname URL
 
 OPTIONS
 =======

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -742,6 +742,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes-bind-dirs.d/30_cron.conf
 /usr/share/applications/qubes-run-terminal.desktop
 /usr/share/applications/qubes-open-file-manager.desktop
+/usr/share/applications/qvm-open-in-dvm.desktop
 /usr/share/qubes/serial.conf
 /usr/share/qubes/marker-vm
 /usr/share/glib-2.0/schemas/20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override


### PR DESCRIPTION
This is adding a "open in disposable VM" option to desktop environment.  For example, when using a file browser, right clicking then selecting "open with" would give opening in a disposable VM as a option.  file browsers are not the intended target as they already have this functionality built in, but this makes it a option for 

this allows things like: 
`xdg-settings set default-web-browser qvm-open-in-dvm.desktop`
to be done by the user.
This does not change any any of the system defaults and it does not get used automatically
