### PR TITLE
systemd-logind: disable watchdog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ SYSTEM_DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.sock
 SYSTEM_DROPINS += systemd-random-seed.service
 SYSTEM_DROPINS += tor.service tor@default.service
 SYSTEM_DROPINS += systemd-timesyncd.service
+SYSTEM_DROPINS += systemd-logind.service
 
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -101,6 +101,7 @@ lib/systemd/system/tmp.mount.d/30_qubes.conf
 lib/systemd/system/tor.service.d/30_qubes.conf
 lib/systemd/system/tor@default.service.d/30_qubes.conf
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
+lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules
 usr/bin/qubes-desktop-run
 usr/bin/qubes-open

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -958,6 +958,7 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/serial-getty@.service.d/30_qubes.conf
 /usr/lib/systemd/system/systemd-random-seed.service.d/30_qubes.conf
 /usr/lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
+/usr/lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 /usr/lib/systemd/system/tinyproxy.service.d/30_not_needed_in_qubes_by_default.conf
 /usr/lib/systemd/system/tor.service.d/30_qubes.conf
 /usr/lib/systemd/system/tor@default.service.d/30_qubes.conf

--- a/vm-systemd/systemd-logind.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-logind.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Service]
+WatchdogSec=0


### PR DESCRIPTION
Upon VM unpause the watchdog may otherwise trigger and restart the
service. Since a systemd-logind restart causes Xorg to restart,
qubes-gui-agent runs into issues, VM windows close down and disposable
VMs are shut down.
So for the sake of reliable unpausing it's better to just disable it.

Fixes QubesOS/qubes-issues#5988

Thanks again to @rustybird for the hint on where to put this.