### PR TITLE
qubes.Syslog

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -26,6 +26,7 @@ etc/qubes-rpc/qubes.SelectDirectory
 etc/qubes-rpc/qubes.SelectFile
 etc/qubes-rpc/qubes.SetDateTime
 etc/qubes-rpc/qubes.StartApp
+etc/qubes-rpc/qubes.Syslog
 etc/qubes-rpc/qubes.SuspendPost
 etc/qubes-rpc/qubes.SuspendPostAll
 etc/qubes-rpc/qubes.SuspendPre

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -68,6 +68,7 @@ install:
 		qubes.InstallUpdatesGUI \
 		qubes.ResizeDisk \
 		qubes.StartApp \
+		qubes.Syslog \
 		qubes.PostInstall \
 		qubes.GetDate \
 		qubes.ShowInTerminal \

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+# vim: fileencoding=utf-8
+#
+# The Qubes OS Project, https://www.qubes-os.org/
+#
+# Copyright (C) 2021
+#                   David Hobach <tripleh@hackingthe.net>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+
+'''
+Qrexec service to forward logs to. Useful to forward logs from multiple VMs to
+a single VM.
+
+All logs sent to this service are roughly sanitized and then passed over to the
+configured system logger (usually systemd/journald listening at `/dev/log`
+nowadays).
+
+A single log entry must be UTF-8 encoded and fit on a single line ending with `\n`.
+
+Logs may have any of the following two formats:
+1. [message]       (example: `this is a log entry`)
+2. [PRI] [message] (example: `<165>This is another log entry.`)
+
+[PRI]:     As defined in [RFC3164] and [RFC5424].
+[message]: An arbitrary string without newline. This service removes
+           non-printable characters and truncates messages at 1500 characters.
+
+Please note that the internal message structure is not sanitized. So any receiving
+application should perform its own sanitization, if the message is structured
+further.
+
+For example, a user could deploy the following rsyslog configuration in a sending
+VM at `/etc/rsyslog.d/qubes_syslog.conf` (requires `systemctl restart rsyslog`):
+```
+module(load="omprog")
+
+template(name="qubes_syslog" type="string"
+    string="<%PRI%>%TIMESTAMP:::date-rfc3339% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n")
+
+ruleset(name="qubes") {
+  action(
+    type="omprog"
+    binary="/usr/sbin/runuser -u user -- /usr/bin/qrexec-client-vm work qubes.Syslog"
+    template="qubes_syslog"
+  )
+}
+
+#apply your filtering here (*.* just forwards all logs)
+*.* call qubes
+```
+
+Users can also e.g. pipe stored log files to a VM via
+`qrexec-client-vm vm qubes.Syslog < /path/to/some/logfile`.
+
+References:
+[RFC3164]: https://datatracker.ietf.org/doc/html/rfc3164
+[RFC5424]: https://datatracker.ietf.org/doc/html/rfc5424
+'''
+
+import io
+import sys
+import os
+import logging
+import syslog
+import re
+import unicodedata
+
+def get_logger():
+    log = logging.getLogger("qubes.Syslog")
+    log.setLevel(logging.INFO)
+    return log
+
+#globals
+LOG = get_logger()
+SEV2SYSLOG = {
+    0: syslog.LOG_EMERG,
+    1: syslog.LOG_ALERT,
+    2: syslog.LOG_CRIT,
+    3: syslog.LOG_ERR,
+    4: syslog.LOG_WARNING,
+    5: syslog.LOG_NOTICE,
+    6: syslog.LOG_INFO,
+    7: syslog.LOG_DEBUG,
+}
+
+def extract_priority(pri):
+    severity = pri % 8
+    return SEV2SYSLOG[severity]
+
+def filter_non_printable(string):
+    ret = []
+    for ch in string:
+        cat = unicodedata.category(ch)
+        if cat[0] == "C":
+            ret += "_"
+        else:
+            ret += ch
+    return ''.join(ret)
+
+def sanitize(untrusted):
+    untr = untrusted.rstrip("\n").rstrip("\r")
+
+    #truncate
+    untr = (untr[:1500] + '..') if len(untr) > 1500 else untr
+
+    m = re.match(r"^<([0-9]{1,3})>.*$", untr)
+    if m:
+        prio = extract_priority(int(m.group(1)))
+    else:
+        prio = syslog.LOG_INFO
+
+    return prio, filter_non_printable(untr)
+
+def handle_untrusted(vm):
+    pid = os.getpid()
+    syslog.openlog(ident=f"qubes.Syslog|{vm}[{pid}]", facility=syslog.LOG_USER)
+
+    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
+    for untrusted_line in input_stream:
+        #NOTE: sys.stdin is text-only in python by default (but might give us byte strings?)
+        if not isinstance(untrusted_line, str):
+            LOG.warning(f"Received non-string content from VM {vm}.")
+            continue
+
+        trusted_prio, trusted_msg = sanitize(untrusted_line)
+        syslog.syslog(trusted_prio, trusted_msg)
+
+    syslog.closelog()
+
+def main():
+    vm = os.environ.get("QREXEC_REMOTE_DOMAIN")
+    if not vm:
+        LOG.error("Failed to identify the source VM.")
+        sys.exit(4)
+    handle_untrusted(vm)
+
+if __name__ == "__main__":
+    main()

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -39,8 +39,9 @@ Logs may have any of the following two formats:
 [message]: An arbitrary string without newline. This service removes
            non-printable characters and truncates messages at 1500 characters.
            By default non-ASCII characters are replaced with question marks.
-           To allow unicode, set QubesDB `/qrexec/allow-unicode` to `True`. This
-           infers security risks with unicode parsing bugs in log viewers.
+           To allow unicode, set QubesDB `/qrexec/qubes-syslog/allow-unicode` to
+           `True`. This infers security risks with unicode parsing bugs in log
+           viewers.
 
 Please note that the internal message structure is not sanitized. So any receiving
 application should perform its own sanitization, if the message is structured
@@ -155,7 +156,7 @@ def main():
         sys.exit(4)
 
     qdb = qubesdb.QubesDB()
-    unicode_str = (qdb.read('/qrexec/allow-unicode') or b'False').decode()
+    unicode_str = (qdb.read('/qrexec/qubes-syslog/allow-unicode') or b'False').decode()
     allow_unicode = True if unicode_str == "True" else False
     handle_untrusted(vm, allow_unicode=allow_unicode)
 

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -38,6 +38,9 @@ Logs may have any of the following two formats:
 [PRI]:     As defined in [RFC3164] and [RFC5424].
 [message]: An arbitrary string without newline. This service removes
            non-printable characters and truncates messages at 1500 characters.
+           By default non-ASCII characters are replaced with question marks.
+           To allow unicode, set QubesDB `/qrexec/allow-unicode` to `True`. This
+           infers security risks with unicode parsing bugs in log viewers.
 
 Please note that the internal message structure is not sanitized. So any receiving
 application should perform its own sanitization, if the message is structured
@@ -78,6 +81,7 @@ import logging
 import syslog
 import re
 import unicodedata
+import qubesdb
 
 def get_logger():
     log = logging.getLogger("qubes.Syslog")
@@ -106,12 +110,12 @@ def filter_non_printable(string):
     for ch in string:
         cat = unicodedata.category(ch)
         if cat[0] == "C":
-            ret += "_"
+            ret += "?"
         else:
             ret += ch
     return ''.join(ret)
 
-def sanitize(untrusted):
+def sanitize(untrusted, allow_unicode=False):
     untr = untrusted.rstrip("\n").rstrip("\r")
 
     #truncate
@@ -123,9 +127,12 @@ def sanitize(untrusted):
     else:
         prio = syslog.LOG_INFO
 
+    if not allow_unicode:
+        untr = untr.encode(encoding="ascii", errors="replace").decode()
+
     return prio, filter_non_printable(untr)
 
-def handle_untrusted(vm):
+def handle_untrusted(vm, allow_unicode=False):
     pid = os.getpid()
     syslog.openlog(ident=f"qubes.Syslog|{vm}[{pid}]", facility=syslog.LOG_USER)
 
@@ -136,7 +143,7 @@ def handle_untrusted(vm):
             LOG.warning(f"Received non-string content from VM {vm}.")
             continue
 
-        trusted_prio, trusted_msg = sanitize(untrusted_line)
+        trusted_prio, trusted_msg = sanitize(untrusted_line, allow_unicode=allow_unicode)
         syslog.syslog(trusted_prio, trusted_msg)
 
     syslog.closelog()
@@ -146,7 +153,11 @@ def main():
     if not vm:
         LOG.error("Failed to identify the source VM.")
         sys.exit(4)
-    handle_untrusted(vm)
+
+    qdb = qubesdb.QubesDB()
+    unicode_str = (qdb.read('/qrexec/allow-unicode') or b'False').decode()
+    allow_unicode = True if unicode_str == "True" else False
+    handle_untrusted(vm, allow_unicode=allow_unicode)
 
 if __name__ == "__main__":
     main()

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -58,7 +58,7 @@ template(name="qubes_syslog" type="string"
 ruleset(name="qubes") {
   action(
     type="omprog"
-    binary="/usr/sbin/runuser -u user -- /usr/bin/qrexec-client-vm work qubes.Syslog"
+    binary="/usr/sbin/runuser -u user -- /usr/bin/qrexec-client-vm receiving_VM qubes.Syslog"
     template="qubes_syslog"
   )
 }

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -129,7 +129,7 @@ def sanitize(untrusted, allow_unicode=False):
         prio = syslog.LOG_INFO
 
     if not allow_unicode:
-        untr = untr.encode(encoding="ascii", errors="replace").decode()
+        untr = untr.encode(encoding="ascii", errors="replace").decode("ascii")
 
     return prio, filter_non_printable(untr)
 

--- a/qubes-rpc/qubes.Syslog
+++ b/qubes-rpc/qubes.Syslog
@@ -84,6 +84,25 @@ import re
 import unicodedata
 import qubesdb
 
+class LimitingTextIOWrapper(io.TextIOWrapper):
+    ''' A TextIOWrapper with a limit on chars to read per line. '''
+
+    def __init__(self, *args, limit=-1, **kwargs):
+        self._limit = limit
+        self._accept = True
+        super().__init__(*args, **kwargs)
+
+    def readline(self, size=-1):
+        read = super().readline(self._limit)
+        if not read: #EOF
+            return read
+
+        if self._accept:
+            self._accept = (read[-1] == "\n")
+            return read
+        self._accept = (read[-1] == "\n")
+        return "\n"
+
 def get_logger():
     log = logging.getLogger("qubes.Syslog")
     log.setLevel(logging.INFO)
@@ -91,6 +110,7 @@ def get_logger():
 
 #globals
 LOG = get_logger()
+MAX_LINE_SIZE = 1500
 SEV2SYSLOG = {
     0: syslog.LOG_EMERG,
     1: syslog.LOG_ALERT,
@@ -116,12 +136,7 @@ def filter_non_printable(string):
             ret += ch
     return ''.join(ret)
 
-def sanitize(untrusted, allow_unicode=False):
-    untr = untrusted.rstrip("\n").rstrip("\r")
-
-    #truncate
-    untr = (untr[:1500] + '..') if len(untr) > 1500 else untr
-
+def sanitize(untr, allow_unicode=False):
     m = re.match(r"^<([0-9]{1,3})>.*$", untr)
     if m:
         prio = extract_priority(int(m.group(1)))
@@ -137,11 +152,15 @@ def handle_untrusted(vm, allow_unicode=False):
     pid = os.getpid()
     syslog.openlog(ident=f"qubes.Syslog|{vm}[{pid}]", facility=syslog.LOG_USER)
 
-    input_stream = io.TextIOWrapper(sys.stdin.buffer, encoding="utf-8")
+    input_stream = LimitingTextIOWrapper(sys.stdin.buffer, encoding="utf-8", limit=MAX_LINE_SIZE)
     for untrusted_line in input_stream:
         #NOTE: sys.stdin is text-only in python by default (but might give us byte strings?)
         if not isinstance(untrusted_line, str):
             LOG.warning(f"Received non-string content from VM {vm}.")
+            continue
+
+        untrusted_line = untrusted_line.rstrip("\n")
+        if not untrusted_line:
             continue
 
         trusted_prio, trusted_msg = sanitize(untrusted_line, allow_unicode=allow_unicode)
@@ -157,7 +176,7 @@ def main():
 
     qdb = qubesdb.QubesDB()
     unicode_str = (qdb.read('/qrexec/qubes-syslog/allow-unicode') or b'False').decode()
-    allow_unicode = True if unicode_str == "True" else False
+    allow_unicode = (unicode_str == "True")
     handle_untrusted(vm, allow_unicode=allow_unicode)
 
 if __name__ == "__main__":

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -643,6 +643,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes-rpc/qubes.InstallUpdatesGUI
 %config(noreplace) /etc/qubes-rpc/qubes.ResizeDisk
 %config(noreplace) /etc/qubes-rpc/qubes.StartApp
+%config(noreplace) /etc/qubes-rpc/qubes.Syslog
 %config(noreplace) /etc/qubes-rpc/qubes.PostInstall
 %config(noreplace) /etc/qubes-rpc/qubes.GetDate
 %config(noreplace) /etc/qubes-rpc/qubes.TemplateSearch


### PR DESCRIPTION
This is a qrexec service to receive logs.

Fixes QubesOS/qubes-issues#830

All the doc is in the file header.

The packaging should work. I don't see the point of providing a default RPC policy for this qrexec service as it requires user intervention anyway.