### PR TITLE
Allow user to choose username for qube console login

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -101,7 +101,7 @@ package_qubes-vm-core() {
     cat <<EOF > "$pkgdir/etc/systemd/system/getty@tty1.service.d/autologin.conf"
 [Service]
 ExecStart=
-ExecStart=-/usr/bin/agetty --autologin user --noclear %I 38400 linux
+ExecStart=-/sbin/agetty -o '-f -p -- \\u' --keep-baud 115200,38400,9600 %I linux
 EOF
 
     # Archlinux packaging guidelines: /var/run is a symlink to a tmpfs. Don't create it

--- a/vm-systemd/serial-getty@.service.d/30_qubes.conf
+++ b/vm-systemd/serial-getty@.service.d/30_qubes.conf
@@ -1,3 +1,3 @@
 [Service]
 ExecStart=
-ExecStart=-/sbin/agetty --autologin root --login-pause --keep-baud 115200,38400,9600 %I $TERM
+ExecStart=-/sbin/agetty -o '-f -p -- \\u' --keep-baud 115200,38400,9600 %I $TERM


### PR DESCRIPTION
Nested logins don’t really work on Linux, and one often wants to login
as ‘user’, not as ‘root’.