### PR TITLE
Set the SELinux context of xendriverdomain.service

### DIFF
--- a/vm-systemd/xendriverdomain.service
+++ b/vm-systemd/xendriverdomain.service
@@ -5,6 +5,7 @@ ConditionVirtualization=xen
 [Service]
 Type=forking
 ExecStart=/usr/sbin/xl devd
+SELinuxContext=system_u:system_r:xend_t:s0-s0:c0.c1023
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This is a step towards having SELinux enforcing in Fedora qubes.