### PR TITLE
Also reload DNS on "vpn-up" event from NetworkManager

### DIFF
--- a/network/qubes-nmhook
+++ b/network/qubes-nmhook
@@ -4,7 +4,7 @@
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
 
-if [ "$2" = "up" ]; then
+if [ "$2" = "up" ] || [ "$2" = "vpn-up" ]; then
     /usr/lib/qubes/qubes-setup-dnat-to-ns
 
     # FIXME: Tinyproxy does not reload DNS servers.


### PR DESCRIPTION
This PR (at least partly) addresses https://github.com/QubesOS/qubes-issues/issues/5648 as currently, DNS resolution will not work for VPN connections configured via the `NetworkManager`, because `qubes-nmhook` is not executed for `vpn-up` events.