### PR TITLE
Disable xfce4-power-manager in qubes-session

### DIFF
--- a/autostart-dropins/xfce4-power-manager.desktop
+++ b/autostart-dropins/xfce4-power-manager.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+NotShowIn=X-QUBES;


### PR DESCRIPTION
Add a drop-in to disable xfce4-power-manager under qubes-session. It
should still be normally active under real Xfce session.