### PR TITLE
network: reload DNS on vpn-down event too

### DIFF
--- a/network/qubes-nmhook
+++ b/network/qubes-nmhook
@@ -4,7 +4,7 @@
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
 
-if [ "$2" = "up" ] || [ "$2" = "vpn-up" ]; then
+if [ "$2" = "up" ] || [ "$2" = "vpn-up" ] || [ "$2" = "vpn-down" ]; then
     /usr/lib/qubes/qubes-setup-dnat-to-ns
 
     # FIXME: Tinyproxy does not reload DNS servers.


### PR DESCRIPTION
This fixes name resolution when VPN connection is lost in case dns overriding