### PR TITLE
Use $(file <) instead of $(shell cat)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := $(shell cat version)
+VERSION := $(file <version)
 
 LIBDIR ?= /usr/lib
 SYSLIBDIR ?= /lib

--- a/Makefile.builder
+++ b/Makefile.builder
@@ -9,7 +9,7 @@ ifeq ($(PACKAGE_SET),vm)
   ARCH_BUILD_DIRS := archlinux
 endif
 
-source-debian-quilt-copy-in: VERSION = $(shell cat $(ORIG_SRC)/version)
+source-debian-quilt-copy-in: VERSION = $(file <$(ORIG_SRC)/version)
 source-debian-quilt-copy-in: ORIG_FILE = "$(CHROOT_DIR)/$(DIST_SRC)/../qubes-core-agent_$(VERSION).orig.tar.gz"
 ifneq ($(filter $(DIST), jessie stretch),)
 source-debian-quilt-copy-in: series_ext = -$(DIST)


### PR DESCRIPTION
The former is faster and handles errors (such as permission denied
reading the file) correctly.