### PR TITLE
rpm: build misc and qubes-rpc dirs via the main makefile

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -299,9 +299,7 @@ Thunar support for Qubes VM tools
 
 %build
 %{?set_build_flags}
-for dir in qubes-rpc misc; do
-  make -C $dir BACKEND_VMM=@BACKEND_VMM@
-done
+make BACKEND_VMM=@BACKEND_VMM@
 make -C doc manpages
 
 %pre


### PR DESCRIPTION
This is especially needed since misc/Makefile expects VERSION variable
set in the main makefile. Otherwise marker-vm file is broken (lacks version
info).