### PR TITLE
qubes-vm-core: allow python<3.11 as a dependency

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -67,7 +67,7 @@ package_qubes-vm-core() {
              python-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg
              socat pacman-contrib
              # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-             'python<3.10'
+             'python<3.11'
              )
     optdepends=(gnome-keyring gnome-settings-daemon python-nautilus gpk-update-viewer qubes-vm-networking qubes-vm-keyring)
     install=PKGBUILD.install

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring qubes-vm-passwordless-root)
 pkgver=$(cat version) || exit 1
-pkgrel=15
+pkgrel=16
 epoch=
 pkgdesc="The Qubes core files for installation inside a Qubes VM."
 arch=("x86_64")


### PR DESCRIPTION
The python v3.10 is finally out in the official arch repositories:
- https://archlinux.org/packages/core/x86_64/python/

The python dependecy should be updated. This change should be also backported to PKGBUILD for Qubes v4.0.

@lubellier, could you help me to test this change?

I have tested the change in my arch template and it seems that everything works as expected.

Thanks,
O.