### PR TITLE
Remove `ip neighbor` hacks

### DIFF
--- a/network/setup-ip
+++ b/network/setup-ip
@@ -24,7 +24,6 @@ configure_network() {
     local gateway6="$8"
     local primary_dns="$9"
     local secondary_dns="${10}"
-    local netvm_mac=fe:ff:ff:ff:ff:ff
 
     /sbin/ifconfig "$INTERFACE" "$ip" netmask "$netmask"
     if [ -n "$ip6" ]; then

--- a/network/setup-ip
+++ b/network/setup-ip
@@ -27,12 +27,8 @@ configure_network() {
     local netvm_mac=fe:ff:ff:ff:ff:ff
 
     /sbin/ifconfig "$INTERFACE" "$ip" netmask "$netmask"
-    /sbin/ip -- neighbour replace to "$gateway" dev "$INTERFACE" \
-        lladdr "$netvm_mac" nud permanent
     if [ -n "$ip6" ]; then
         /sbin/ifconfig "$INTERFACE" add "$ip6/$netmask6"
-        /sbin/ip -- neighbour replace to "$gateway6" dev "$INTERFACE" \
-            lladdr "$netvm_mac" nud permanent
     fi
     /sbin/ifconfig "$INTERFACE" up
 

--- a/network/vif-qubes-nat.sh
+++ b/network/vif-qubes-nat.sh
@@ -94,8 +94,6 @@ if test "$command" == online; then
         netns iptables -t nat -I POSTROUTING -o "$netns_appvm_if" -s "$netvm_dns2_ip" -j SNAT --to-source "$appvm_dns2_ip"
     fi
 
-    netns ip neighbour add to "$appvm_ip" dev "$netns_appvm_if" lladdr "$mac" nud permanent
-    netns ip neighbour add to "$netvm_gw_ip" dev "$netns_netvm_if" lladdr "$netvm_mac" nud permanent
     netns ip addr add "$netvm_ip" dev "$netns_netvm_if"
     netns ip addr add "$appvm_gw_ip" dev "$netns_appvm_if"
 

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -164,10 +164,6 @@ if [ "${ip}" ]; then
             "$iptables_cmd ! -i vif+ -s ${addr} -j DROP" \
             "COMMIT" |
             ${cmdprefix} "$ipt" --noflush $ipt_arg
-        if [[ "$command" = 'online' ]]; then
-            ip -- neighbour "${ipcmd}" to "${addr}" \
-                dev "${vif}" lladdr "$mac" nud permanent
-        fi
         if ! conntrack_purge -s "$addr" || ! conntrack_purge -d "$addr"; then
             printf 'Cannot purge stale conntrack entries for %q\n' "$addr">&2
             exit 1


### PR DESCRIPTION
They cause all sorts of regressions, of which QubesOS/qubes-issues#7123
is just the most recent.  In the future, Qubes OS should switch to pure
layer-3 links between qubes, with no layer-2 addressing at all.  That is
for another day, however.

Fixes QubesOS/qubes-issues#7123 and possibly a few other issues.