### PR TITLE
Fail boot if random seed doesn't get initialized

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,8 @@ install-systemd-dropins:
 	    install -d $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d ;\
 	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d/ ;\
 	done
+	install -d $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
+	ln -sf ../systemd-random-seed.service $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
 
 	# Install user dropins
 	@for dropin in $(USER_DROPINS); do \

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -99,6 +99,7 @@ lib/systemd/system/tinyproxy.service.d/30_not_needed_in_qubes_by_default.conf
 lib/systemd/system/tmp.mount.d/30_qubes.conf
 lib/systemd/system/tor.service.d/30_qubes.conf
 lib/systemd/system/tor@default.service.d/30_qubes.conf
+lib/systemd/system/sysinit.target.requires
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules

--- a/debian/qubes-core-agent.links
+++ b/debian/qubes-core-agent.links
@@ -32,3 +32,6 @@
 /usr/share/themes /usr/share/qubes/xdg-override/themes
 /usr/share/wayland-sessions /usr/share/qubes/xdg-override/wayland-sessions
 /usr/share/xsessions /usr/share/qubes/xdg-override/xsessions
+
+## systemd stuff
+/lib/systemd/system/systemd-random-seed.service /lib/systemd/system/sysinit.target.requires/systemd-random-seed.service

--- a/init/functions
+++ b/init/functions
@@ -81,13 +81,6 @@ is_updateable() {
     [ "$(qubesdb-read /qubes-vm-updateable)" = "True" ]
 }
 
-reload_random_seed() {
-    local seed
-    seed=$(qubesdb-read /qubes-random-seed)
-    echo "$seed" | base64 -d > /dev/urandom
-    qubesdb-rm /qubes-random-seed
-}
-
 is_protected_file() {
     local ret=1
     local pfilelist

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -982,6 +982,7 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/tor.service.d/30_qubes.conf
 /usr/lib/systemd/system/tor@default.service.d/30_qubes.conf
 /usr/lib/systemd/system/tmp.mount.d/30_qubes.conf
+/usr/lib/systemd/system/sysinit.target.requires/systemd-random-seed.service
 /usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
 /usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 

--- a/vm-systemd/qubes-random-seed.sh
+++ b/vm-systemd/qubes-random-seed.sh
@@ -1,10 +1,2 @@
-#!/bin/bash
-
-# Source Qubes library.
-# shellcheck source=init/functions
-. /usr/lib/qubes/init/functions
-
-set -e
-set -o pipefail
-
-reload_random_seed
+#!/bin/bash --
+qubesdb-read -w /qubes-random-seed > /dev/urandom && exec qubesdb-rm /qubes-random-seed

--- a/vm-systemd/systemd-random-seed.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-random-seed.service.d/30_qubes.conf
@@ -1,5 +1,6 @@
 [Unit]
 After=qubes-db.service
+Before=sysinit.target
 
 [Service]
-ExecStart=/usr/lib/qubes/init/qubes-random-seed.sh
+ExecStartPre=/usr/lib/qubes/init/qubes-random-seed.sh


### PR DESCRIPTION
The random seed seems to (rarely) not get initialized.  This will ensure
that the random seed must be initialized for the system to successfully
boot.