### PR TITLE
Fix GSettings when XDG_DATA_DIRS is overridden

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -27,7 +27,7 @@ install:
 	    marker-vm \
 	    qubes-master-key.asc
 	install -D -m 0644 mime-globs $(DESTDIR)$(QUBESDATADIR)/mime-override/globs
-	for i in X11 aclocal appdata augeas backgrounds bash-completion desktop-directories dict doc empty games gnome help icons idl info licenses locale man metainfo mime-info misc omf pixmaps sounds themes wayland-sessions xsessions; do \
+	for i in X11 aclocal appdata augeas backgrounds bash-completion desktop-directories dict doc empty games glib-2.0 gnome help icons idl info licenses locale man metainfo mime-info misc omf pixmaps sounds themes wayland-sessions xsessions; do \
 		ln -sf "../../$$i" $(DESTDIR)$(QUBESMIMEDIR)/"$$i"; \
 	done
 	$(RM) mime/icons


### PR DESCRIPTION
GSettings requires that glib-2.0 be found in XDG_DATA_DIRS or the program crashes.  Debian packages already installed the needed symlink, but Fedora and Arch packages did not.

Tested by creating the symlink manually in a qube and finding that the problem went away.

Fixes QubesOS/qubes-issues#7137.