### PR TITLE
Replace net-tools with iproute2

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -35,8 +35,6 @@ build() {
     done
 
     # Fix for network tools paths
-    sed 's:/sbin/ifconfig:ifconfig:g' -i network/*
-    sed 's:/sbin/route:route:g' -i network/*
     sed 's:/sbin/ethtool:ethtool:g' -i network/*
     sed 's:/sbin/ip:ip:g' -i network/*
     sed 's:/bin/grep:grep:g' -i network/*
@@ -61,7 +59,7 @@ package_qubes-vm-core() {
         exit 1
     }
     release=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}
-    depends=(qubes-vm-utils python python-xdg ethtool ntp net-tools
+    depends=(qubes-vm-utils python python-xdg ethtool ntp iproute2
              gnome-packagekit imagemagick fakeroot notification-daemon dconf
              zenity qubes-libvchan qubes-db-vm haveged python-gobject
              python-dbus xdg-utils notification-daemon gawk sed procps-ng librsvg
@@ -119,7 +117,7 @@ EOF
 #
 package_qubes-vm-networking() {
     pkgdesc="Qubes OS tools allowing to use a Qubes VM as a NetVM/ProxyVM"
-    depends=(qubes-vm-core qubes-vm-utils python ethtool net-tools
+    depends=(qubes-vm-core qubes-vm-utils python ethtool iproute2
              qubes-db-vm networkmanager iptables tinyproxy nftables
              conntrack-tools
              )

--- a/debian/control
+++ b/debian/control
@@ -125,7 +125,6 @@ Depends:
     qubes-core-agent (= ${binary:Version}),
     tinyproxy,
     iptables,
-    net-tools,
     ethtool,
     conntrack,
     socat,

--- a/network/setup-ip
+++ b/network/setup-ip
@@ -25,11 +25,11 @@ configure_network() {
     local primary_dns="$9"
     local secondary_dns="${10}"
 
-    /sbin/ifconfig "$INTERFACE" "$ip" netmask "$netmask"
+    /sbin/ip address add "$ip/$netmask" dev "$INTERFACE"
     if [ -n "$ip6" ]; then
-        /sbin/ifconfig "$INTERFACE" add "$ip6/$netmask6"
+        /sbin/ip address add "$ip6/$netmask6" dev "$INTERFACE"
     fi
-    /sbin/ifconfig "$INTERFACE" up
+    /sbin/ip link set dev "$INTERFACE" up
 
     if [ -n "$gateway" ]; then
         add_host_route "$gateway" "$INTERFACE"

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -177,7 +177,7 @@ if [ "${ip}" ]; then
 fi
 
 if [ "$command" = "online" ]; then
-    ifconfig "${vif}" up
+    ip link set dev "${vif}" up
 fi
 
 if [ "${ip}" ]; then

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -242,7 +242,6 @@ Summary:    Networking support for Qubes VM
 Requires:   ethtool
 Requires:   iptables
 Requires:   conntrack-tools
-Requires:   net-tools
 Requires:   iproute
 Requires:   nftables
 Requires:   socat


### PR DESCRIPTION
The ifconfig command is obsolete on Linux.  Replace it with `ip` from
the iproute2 package.  This allows dropping the net-tools dependency
altogether.

Fixes QubesOS/qubes-issues#7142.