### PR TITLE
Enable proxy NDP if IPv6 is enabled

### DIFF
--- a/network/vif-qubes-nat.sh
+++ b/network/vif-qubes-nat.sh
@@ -26,7 +26,7 @@ netns_appvm_if="${vif}"
 #               '----------------------------------'
 #
 
-readonly netvm_mac=fe:ff:ff:ff:ff:ff
+readonly netvm_mac=fe:ff:ff:ff:ff:ff mac=00:16:3e:5e:6c:00
 
 function run
 {

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -102,7 +102,7 @@ if ! [[ $vif =~ ^vif(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
     exit 1
 fi
 
-domid=${BASH_REMATCH[1]} sub=${BASH_REMATCH[2]}
+domid=${BASH_REMATCH[1]}
 
 # metric must be positive, but prefer later interface
 #  32752 is max XID aka domid

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -120,7 +120,7 @@ case "$command" in
         ipcmd='add'
         iptables_cmd='-I PREROUTING 1'
         cmdprefix=''
-        ipv6_disabled=$(cat /proc/sys/net/ipv6/conf/"${vif}"/disable_ipv6 || echo 1)
+        ipv6_disabled=$(cat "/proc/sys/net/ipv6/conf/$vif/disable_ipv6" || echo 1)
         # without a MAC address we will fail later with a confusing error
         mac=$(xenstore-read "backend/vif/$domid/$sub/mac") || exit 1
         ;;
@@ -185,7 +185,7 @@ if [ "${ip}" ]; then
     # the guest using those addresses.
     for addr in ${ip};
     do
-        if [[ "$addr" = *:* ]] && [[ "$ipv6_disabled" = 1 ]]; then
+        if [[ "$addr" = *:* ]] && [[ "$ipv6_disabled" != '0' ]]; then
             log error "Cannot set IPv6 route to ${addr}, IPv6 disabled in the kernel"
             continue
         fi
@@ -194,7 +194,7 @@ if [ "${ip}" ]; then
         network_hooks "${command}" "${vif}" "${addr}"
     done
     ${cmdprefix} ip addr "${ipcmd}" "${back_ip}/32" dev "${vif}"
-    if [ "${back_ip6}" ] && [[ "${back_ip6}" != "fe80:"* ]] && [[ "$ipv6_disabled" != 1 ]]; then
+    if [ "${back_ip6}" ] && [[ "${back_ip6}" != "fe80:"* ]] && [[ "$ipv6_disabled" = '0' ]]; then
         ${cmdprefix} ip addr "${ipcmd}" "${back_ip6}/128" dev "${vif}"
     fi
 else

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -121,8 +121,6 @@ case "$command" in
         iptables_cmd='-I PREROUTING 1'
         cmdprefix=''
         ipv6_disabled=$(cat "/proc/sys/net/ipv6/conf/$vif/disable_ipv6" || echo 1)
-        # without a MAC address we will fail later with a confusing error
-        mac=$(xenstore-read "backend/vif/$domid/$sub/mac") || exit 1
         ;;
     offline)
         do_without_error ifdown "${vif}"

--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -196,6 +196,7 @@ if [ "${ip}" ]; then
     ${cmdprefix} ip addr "${ipcmd}" "${back_ip}/32" dev "${vif}"
     if [ "${back_ip6}" ] && [[ "${back_ip6}" != "fe80:"* ]] && [[ "$ipv6_disabled" = '0' ]]; then
         ${cmdprefix} ip addr "${ipcmd}" "${back_ip6}/128" dev "${vif}"
+        echo 1 >"/proc/sys/net/ipv6/conf/${vif}/proxy_ndp"
     fi
 else
     network_hooks "${command}" "${vif}"


### PR DESCRIPTION
This is consistent with proxy ARP; if one is enabled, the other should be as well.

The first commit improves error handling for IPv6 being disabled.  The second commit is the actual fix, and the third commit removes an unused variable.
