### PR TITLE
qubes.ShowInTerminal: do not exit on Ctrl-O

### DIFF
--- a/qubes-rpc/qubes.ShowInTerminal
+++ b/qubes-rpc/qubes.ShowInTerminal
@@ -13,7 +13,7 @@ sock="$tmpdir/terminal.sock"
 
 xterm -geometry 80x24 -e /bin/sh -c "
 until [ -S $sock ]; do sleep 0.1; done || true
-exec socat file:/dev/tty,rawer,escape=0x0f UNIX-CONNECT:$sock" &
+exec socat file:/dev/tty,rawer UNIX-CONNECT:$sock" &
 
 trap 'rm -rf -- "$tmpdir"' EXIT
 socat "UNIX-LISTEN:\"$sock\"" -


### PR DESCRIPTION
It causes nasty problems when using vim, for example.

Fixes QubesOS/qubes-issues#7209.