### PR TITLE
Disable CUPS by default

### DIFF
--- a/vm-systemd/qubes-sysinit.sh
+++ b/vm-systemd/qubes-sysinit.sh
@@ -7,7 +7,7 @@
 # List of services enabled by default (in case of absence of qubesdb entry)
 DEFAULT_ENABLED_NETVM="network-manager qubes-network qubes-update-check qubes-updates-proxy meminfo-writer qubes-firewall"
 DEFAULT_ENABLED_PROXYVM="qubes-network qubes-firewall qubes-update-check meminfo-writer"
-DEFAULT_ENABLED_APPVM="cups qubes-update-check meminfo-writer"
+DEFAULT_ENABLED_APPVM="qubes-update-check meminfo-writer"
 DEFAULT_ENABLED_TEMPLATEVM="$DEFAULT_ENABLED_APPVM updates-proxy-setup"
 DEFAULT_ENABLED="meminfo-writer"
 


### PR DESCRIPTION
It is a security risk, slows qube boot, wastes memory and CPU, and is
not necessary.  Fixes QubesOS/qubes-issues#5179.

Reported-by: Patrick Schleizer <adrelanos@whonix.org>

@adrelanos I hope I got the Reported-by correct.