### PR TITLE
Make `apt-get update` exit codes reliable

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -1,6 +1,7 @@
 etc/apt/apt.conf.d/00notify-hook
-etc/apt/apt.conf.d/70no-unattended
 etc/apt/apt.conf.d/10no-cache
+etc/apt/apt.conf.d/41error-on-any
+etc/apt/apt.conf.d/70no-unattended
 etc/apt/sources.list.d/qubes-r4.list
 etc/apt/trusted.gpg.d/qubes-archive-keyring.gpg
 etc/dconf/db/local.d/dpi

--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -59,6 +59,8 @@ install-apt:
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/70no-unattended
 	install -D -m 0644 apt-conf-10no-cache \
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/10no-cache
+	install -D -m 0644 apt-conf-41error-on-any \
+		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/41error-on-any
 
 install-dnf: install-rpm
 	install -D -m 0644 dnf-qubes-hooks.py \

--- a/package-managers/apt-conf-41error-on-any
+++ b/package-managers/apt-conf-41error-on-any
@@ -1,0 +1,1 @@
+APT::Update::Error-Mode "any";


### PR DESCRIPTION
This uses the `APT::Update::Error-Mode` configuration option introduced
in Debian 11 to ensure that all errors in APT cause a non-zero exit
code.

Fixes QubesOS/qubes-issues#1107.

Reported-by: Patrick Schleizer <adrelanos@whonix.org>
Co-authored-by: Patrick Schleizer <adrelanos@whonix.org>