### PR TITLE
firewall log_error: handle all exceptions, allow runuser to be in /sbin

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -198,13 +198,13 @@ class FirewallWorker(object):
                 ['runuser', '-u', user, '--', 'notify-send', '-t', '8000',
                     '--icon=network-error', msg],
                 env={'DISPLAY': ':0',
-                    'PATH': '/usr/sbin:/usr/bin',
+                    'PATH': '/usr/sbin:/usr/bin:/sbin:/bin',
                     #dbus address is needed on fedora, but optional on debian
                     'DBUS_SESSION_BUS_ADDRESS': 'unix:path=/run/user/{}/bus'.format(
                         uid)},
                 stderr=subprocess.STDOUT,
             )
-        except subprocess.SubprocessError as e:
+        except Exception as e:
             self.log.error(
                 'Failed to notify the user about: {} ({})'.format(
                     msg, str(e)


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/7418

Tested 2 cases with `sys-firewall` running Debian bullseye (runuser in `/sbin/runuser`):
1. Added `qvm-firewall sys-vpn add --before 0 accept i-do-not-exist.example.com` and noticed the error notification from notify-send after `sudo systemctl restart qubes-firewall`.
2. Temporarily moved /sbin/runuser and confirmed that the exception is caught, notify-send notification does not appear but an error message `Failed to notify the user about: ...` is logged in `sys-firewall` log.