### PR TITLE
qvm-copy: Always filter escape characters in stderr

### DIFF
--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -82,7 +82,7 @@ for path in "$@"; do
     fi
 done
 
-/usr/lib/qubes/qrexec-client-vm -- "$VM" qubes.Filecopy /usr/lib/qubes/qfile-agent "$@"
+/usr/lib/qubes/qrexec-client-vm --filter-escape-chars-stderr -- "$VM" qubes.Filecopy /usr/lib/qubes/qfile-agent "$@"
 
 if [ "$OPERATION_TYPE" = "move" ] ; then
     rm -rf -- "$@"


### PR DESCRIPTION
qvm-copy has its own error reporting mechanism, which is where all
normal errors will go.