### PR TITLE
Switch default clocksource to 'tsc'

### DIFF
--- a/boot/grub.qubes
+++ b/boot/grub.qubes
@@ -10,4 +10,6 @@ GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX swiotlb=8192"
 # add noresume - to avoid a 30 second hang on Debian HVM boot as it tries to
 # locate swap space for hibernation
 GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX noresume"
+# switch default clocksource to 'tsc' - it's much faster, and safe under Qubes OS
+GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX clocksource=tsc"
 GRUB_TIMEOUT=0


### PR DESCRIPTION
The 'tsc' clocksource is significantly faster than 'xen', and since
Qubes OS does not support VM migration, it is safe to use.
In synthetic benchmarks, it improves performance over tenfold, but
significant improvements in real world use cases is visible too.

Apply the change to in-VM kernel too.

Fixes QubesOS/qubes-issues#7404