### PR TITLE
Rip out network-based update proxy remanents     

### DIFF
--- a/vm-init.d/qubes-updates-proxy
+++ b/vm-init.d/qubes-updates-proxy
@@ -48,9 +48,6 @@ start() {
 
     [ -x "$exec" ] || exit 5
     [ -f $config ] || exit 6
-    # setup network redirection
-    /sbin/iptables -I INPUT -i vif+ -p tcp --dport 8082 -j ACCEPT
-    /sbin/iptables -t nat -A PR-QBS-SERVICES -i vif+ -d 10.137.255.254 -p tcp --dport 8082 -j REDIRECT
 
     echo -n "Starting $prog (as Qubes updates proxy): "
     daemon "$exec" -c $config
@@ -65,8 +62,6 @@ stop() {
     killproc -p $pidfile "$prog"
     retval=$?
     echo
-    /sbin/iptables -t nat -D PR-QBS-SERVICES -i vif+ -d 10.137.255.254 -p tcp --dport 8082 -j REDIRECT
-    /sbin/iptables -D INPUT -i vif+ -p tcp --dport 8082 -j ACCEPT
     [ $retval -eq 0 ] && rm -f "$lockfile"
     return $retval
 }

--- a/vm-init.d/qubes-updates-proxy
+++ b/vm-init.d/qubes-updates-proxy
@@ -52,7 +52,7 @@ start() {
     /sbin/iptables -I INPUT -i vif+ -p tcp --dport 8082 -j ACCEPT
     /sbin/iptables -t nat -A PR-QBS-SERVICES -i vif+ -d 10.137.255.254 -p tcp --dport 8082 -j REDIRECT
 
-    echo -n $"Starting $prog (as Qubes updates proxy): "
+    echo -n "Starting $prog (as Qubes updates proxy): "
     daemon "$exec" -c $config
     retval=$?
     echo

--- a/vm-init.d/qubes-updates-proxy
+++ b/vm-init.d/qubes-updates-proxy
@@ -42,7 +42,7 @@ start() {
     have_qubesdb || return
 
     if qsvc qubes-updates-proxy ; then
-        # Yum proxy disabled
+        # Updates proxy disabled
         exit 0
     fi
 

--- a/vm-init.d/qubes-updates-proxy
+++ b/vm-init.d/qubes-updates-proxy
@@ -28,8 +28,8 @@
 # Check that networking is up.
 [ "$NETWORKING" = "no" ] && exit 0
 
-exec="$(command -v tinyproxy)"
-prog=$(basename "$exec")
+exec=$(command -v tinyproxy) || exit 2
+prog=$(basename "$exec") || exit 2
 config="/etc/tinyproxy/tinyproxy-updates.conf"
 pidfile="/var/run/tinyproxy-updates/tinyproxy.pid"
 
@@ -47,23 +47,23 @@ start() {
     fi
 
     [ -x "$exec" ] || exit 5
-    [ -f $config ] || exit 6
+    [ -f "$config" ] || exit 6
 
     echo -n "Starting $prog (as Qubes updates proxy): "
-    daemon "$exec" -c $config
+    daemon "$exec" -c "$config"
     retval=$?
     echo
-    [ $retval -eq 0 ] && touch $lockfile
-    return $retval
+    [ "$retval" -eq 0 ] && touch -- "$lockfile"
+    return "$retval"
 }
 
 stop() {
     echo -n $"Stopping $prog: "
-    killproc -p $pidfile "$prog"
+    killproc -p "$pidfile" "$prog"
     retval=$?
     echo
-    [ $retval -eq 0 ] && rm -f "$lockfile"
-    return $retval
+    [ "$retval" -eq 0 ] && rm -f -- "$lockfile"
+    return "$retval"
 }
 
 restart() {


### PR DESCRIPTION
732e9d02eeae18c3cfe3c10beceed1564f28c399 removed most of the network-based updates proxy, but it didn't change the SysV init scripts.
