### PR TITLE
network: extract DNS servers IP from resolved service

### DIFF
--- a/debian/qubes-core-agent-networking.install
+++ b/debian/qubes-core-agent-networking.install
@@ -19,6 +19,7 @@ usr/lib/qubes/init/network-proxy-setup.sh
 usr/lib/qubes/init/network-proxy-stop.sh
 usr/lib/qubes/init/network-uplink-wait.sh
 usr/lib/qubes/init/qubes-iptables
+usr/lib/qubes/get-dns-from-resolved
 usr/lib/qubes/qubes-setup-dnat-to-ns
 usr/lib/qubes/setup-ip
 usr/lib/tmpfiles.d/qubes-core-agent-linux.conf

--- a/network/Makefile
+++ b/network/Makefile
@@ -12,6 +12,7 @@ install:
 	install -t $(DESTDIR)$(QUBESLIBDIR) \
 		setup-ip \
 		tinyproxy-wrapper \
+		get-dns-from-resolved \
 		update-proxy-configs
 	install -d $(DESTDIR)$(BINDIR)
 	install -t $(DESTDIR)$(BINDIR) \

--- a/network/get-dns-from-resolved
+++ b/network/get-dns-from-resolved
@@ -1,0 +1,49 @@
+#!/usr/bin/python3
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2022  Marek Marczykowski-Górecki
+#                               <marmarek@invisiblethingslab.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+
+import dbus
+
+
+def get_dns():
+    bus = dbus.SystemBus()
+    resolve1 = bus.get_object('org.freedesktop.resolve1',
+                              '/org/freedesktop/resolve1')
+    resolve1_proxy = dbus.Interface(resolve1,
+                                    dbus_interface='org.freedesktop.resolve1')
+    dns = resolve1.Get('org.freedesktop.resolve1.Manager',
+                       'DNS',
+                       dbus_interface='org.freedesktop.DBus.Properties')
+    return dns
+
+
+def print_ipv4_dns(dns):
+    # filter on IPv4 (family 2) and then sort global DNS first
+    dns_filtered_sorted = sorted((d for d in dns if d[1] == 2),
+                                 key=lambda x: x[0] != 0)
+
+    for dns in dns_filtered_sorted:
+        # take only address array
+        address = dns[2]
+        print('nameserver {:d}.{:d}.{:d}.{:d}'.format(*address))
+
+
+if __name__ == '__main__':
+    print_ipv4_dns(get_dns())

--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -18,7 +18,12 @@ export PATH=$PATH:/sbin:/bin
 if [ "X$NS1" = "X" ] ; then exit ; fi
 iptables -t nat -F PR-QBS
 FIRSTONE=yes
-grep ^nameserver /etc/resolv.conf | grep -v ":.*:" | head -2 |
+if systemctl -q is-active systemd-resolved && \
+        grep -q '^nameserver.*127\.0\.0\.53' /etc/resolv.conf; then
+    /usr/lib/qubes/get-dns-from-resolved
+else
+    grep ^nameserver /etc/resolv.conf
+fi | grep -v ":.*:" | head -2 |
         (
         # shellcheck disable=SC2034
         while read -r x y z ; do

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -832,6 +832,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/init/network-proxy-stop.sh
 /usr/lib/qubes/init/network-uplink-wait.sh
 /usr/lib/qubes/init/qubes-iptables
+/usr/lib/qubes/get-dns-from-resolved
 /usr/lib/qubes/qubes-setup-dnat-to-ns
 /usr/lib/qubes/setup-ip
 /usr/lib/tmpfiles.d/qubes-core-agent-linux.conf


### PR DESCRIPTION
When a qube provides network to others, it needs to forward DNS traffic.
If /etc/resolv.conf points at local systemd-resolved, redirecting to it
won't work (and is not a good idea). Instead, forward such queries to
systemd-resolved's upstream servers.

Add a script to get the addresses using systemd-resolved's DBus API.

Fixes QubesOS/qubes-issues#7469