### PR TITLE
Disable pipewire by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,8 +26,8 @@ clean:
 	rm -f .coverage
 
 # Dropin Directory
-SYSTEM_DROPIN_DIR ?= "lib/systemd/system"
-USER_DROPIN_DIR ?= "usr/lib/systemd/user"
+SYSTEM_DROPIN_DIR ?= /lib/systemd/system
+USER_DROPIN_DIR ?= /usr/lib/systemd/user
 
 SYSTEM_DROPINS := boot.automount chronyd.service crond.service
 SYSTEM_DROPINS += cups.service cups-browsed.service cups.path cups.socket ModemManager.service
@@ -76,23 +76,23 @@ endif
 install-systemd-dropins:
 	# Install system dropins
 	@for dropin in $(SYSTEM_DROPINS); do \
-	    install -d $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d ;\
-	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d/ ;\
+	    install -d $(DESTDIR)$(SYSTEM_DROPIN_DIR)/$${dropin}.d ;\
+	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)$(SYSTEM_DROPIN_DIR)/$${dropin}.d/ ;\
 	done
-	install -d $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
-	ln -sf ../systemd-random-seed.service $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
+	install -d $(DESTDIR)$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
+	ln -sf ../systemd-random-seed.service $(DESTDIR)$(SYSTEM_DROPIN_DIR)/sysinit.target.requires
 
 	# Install user dropins
 	@for dropin in $(USER_DROPINS); do \
-	    install -d $(DESTDIR)/$(USER_DROPIN_DIR)/$${dropin}.d ;\
-	    install -m 0644 vm-systemd/user/$${dropin}.d/*.conf $(DESTDIR)/$(USER_DROPIN_DIR)/$${dropin}.d/ ;\
+	    install -d $(DESTDIR)$(USER_DROPIN_DIR)/$${dropin}.d ;\
+	    install -m 0644 vm-systemd/user/$${dropin}.d/*.conf $(DESTDIR)$(USER_DROPIN_DIR)/$${dropin}.d/ ;\
 	done
 
 install-systemd-networking-dropins:
 	# Install system dropins
 	@for dropin in $(SYSTEM_DROPINS_NETWORKING); do \
-	    install -d $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d ;\
-	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)/$(SYSTEM_DROPIN_DIR)/$${dropin}.d/ ;\
+	    install -d $(DESTDIR)$(SYSTEM_DROPIN_DIR)/$${dropin}.d ;\
+	    install -m 0644 vm-systemd/$${dropin}.d/*.conf $(DESTDIR)$(SYSTEM_DROPIN_DIR)/$${dropin}.d/ ;\
 	done
 
 install-init:

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,8 @@ install-systemd: install-init
 	install -m 0644 $(SYSTEMD_CORE_SERVICES) $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/qubes-*.timer $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/75-qubes-vm.preset $(DESTDIR)$(SYSLIBDIR)/systemd/system-preset/
+	install -D -m 0644 vm-systemd/75-qubes-vm.user-preset \
+		$(DESTDIR)$(USER_DROPIN_DIR)-preset/75-qubes-vm.preset
 	install -m 0644 vm-systemd/qubes-core.conf $(DESTDIR)$(SYSLIBDIR)/modules-load.d/
 	install -m 0644 vm-systemd/xendriverdomain.service $(DESTDIR)/etc/systemd/system/
 	install -m 0644 vm-systemd/80-qubes-vif.link $(DESTDIR)$(SYSLIBDIR)/systemd/network/

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -135,6 +135,7 @@ EOF
 ############################
 ## Service Management Functions ##
 ############################
+# FIXME: add user units support to is_static()/is_masked()/mask()/unmask() functions
 is_static() {
     [ -f "/usr/lib/systemd/system/$1" ] && ! grep -q '^[[].nstall]' "/usr/lib/systemd/system/$1"
 }
@@ -166,6 +167,8 @@ unmask() {
 
 preset_units() {
     local represet=
+    # shellcheck disable=SC2206
+    local extra_opts=( $3 )
     while read -r action unit_name
     do
         if [ "$action" = "#" ] && [ "$unit_name" = "Units below this line will be re-preset on package upgrade" ]
@@ -191,15 +194,17 @@ preset_units() {
                     # We masked this static unit before, now we unmask it.
                     unmask "$unit_name"
                 fi
-                systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || :
+                systemctl --no-reload "${extra_opts[@]}" preset "$unit_name" >/dev/null 2>&1 || :
             else
-                systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || :
+                systemctl --no-reload "${extra_opts[@]}" preset "$unit_name" >/dev/null 2>&1 || :
             fi
         fi
     done < "$1"
 }
 
 restore_units() {
+    # shellcheck disable=SC2206
+    local extra_opts=( $2 )
     grep '^[[:space:]]*[^#;]' "$1" | while read -r action unit_name
     do
         if is_static "$unit_name" && is_masked "$unit_name"
@@ -208,7 +213,7 @@ restore_units() {
             # Otherwise systemctl preset will fail badly.
             unmask "$unit_name"
         fi
-        systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || :
+        systemctl --no-reload "${extra_opts[@]}" preset "$unit_name" >/dev/null 2>&1 || :
     done
 }
 
@@ -216,9 +221,11 @@ configure_systemd() {
     if [ "$1" -eq 1 ]
     then
         preset_units /usr/lib/systemd/system-preset/$qubes_preset_file initial
+        preset_units /usr/lib/systemd/user-preset/$qubes_preset_file initial --global
         changed=true
     else
         preset_units /usr/lib/systemd/system-preset/$qubes_preset_file upgrade
+        preset_units /usr/lib/systemd/user-preset/$qubes_preset_file upgrade --global
         changed=true
         # Upgrade path - now qubes-iptables is used instead
         for svc in iptables ip6tables
@@ -399,7 +406,8 @@ pre_remove() {
         # once the Qubes OS preset file is removed.
         mkdir -p /run/qubes-uninstall
         cp -f /usr/lib/systemd/system-preset/$qubes_preset_file /run/qubes-uninstall/
-        cp -f /usr/lib/systemd/system-preset/$qubes_preset_file /run/qubes-uninstall/
+        cp -f /usr/lib/systemd/user-preset/$qubes_preset_file \
+            /run/qubes-uninstall/user-$qubes_preset_file
     fi
 }
 
@@ -412,6 +420,7 @@ post_remove() {
         # We have a saved preset file (or more).
         # Re-preset the units mentioned there.
         restore_units /run/qubes-uninstall/$qubes_preset_file
+        restore_units /run/qubes-uninstall/user-$qubes_preset_file --global
         rm -rf /run/qubes-uninstall
         changed=true
     fi

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -156,6 +156,7 @@ usr/lib/qubes/xdg-icon
 usr/lib/qubes/tinyproxy-wrapper
 usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
 usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
+usr/lib/systemd/user-preset/75-qubes-vm.preset
 usr/share/glib-2.0/schemas/*
 usr/share/kde4/services/*.desktop
 usr/share/kservices5/ServiceMenus/*.desktop

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -26,6 +26,7 @@ debug() {
     fi
 }
 
+# FIXME: add user units support to is_static()/is_masked()/mask()/unmask() functions
 is_static() {
     [ -f "/lib/systemd/system/$1" ] && ! grep -q '^[[].nstall]' "/lib/systemd/system/$1"
 }
@@ -57,6 +58,8 @@ unmask() {
 
 preset_units() {
     local represet=
+    # shellcheck disable=SC2206
+    local extra_opts=( $3 )
     while read -r action unit_name
     do
         if [ "$action" = "#" ] && [ "$unit_name" = "Units below this line will be re-preset on package upgrade" ]
@@ -84,9 +87,9 @@ preset_units() {
                     # We masked this static unit before, now we unmask it.
                     deb-systemd-helper unmask "${unit_name}" > /dev/null 2>&1 || true
                 fi
-                systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || :
+                systemctl --no-reload "${extra_opts[@]}" preset "$unit_name" >/dev/null 2>&1 || :
             else
-                systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || :
+                systemctl --no-reload "${extra_opts[@]}" preset "$unit_name" >/dev/null 2>&1 || :
             fi
         fi
     done < "$1"
@@ -137,11 +140,13 @@ case "${1}" in
 
             # Systemd preload-all
             preset_units /lib/systemd/system-preset/75-qubes-vm.preset initial
+            preset_units /usr/lib/systemd/user-preset/75-qubes-vm.preset initial --global
 
             # Maybe install overridden serial.conf init script
             installSerialConf
         else
             preset_units /lib/systemd/system-preset/75-qubes-vm.preset upgrade
+            preset_units /usr/lib/systemd/user-preset/75-qubes-vm.preset upgrade --global
         fi
         systemctl reenable haveged
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -34,6 +34,7 @@
 %define plateform_python3_sitelib %(/usr/libexec/platform-python -c 'import distutils.sysconfig; print(distutils.sysconfig.get_python_lib())')
 %endif
 
+# FIXME: add user units support to is_static()/is_masked()/mask()/unmask() functions
 %define scriptletfuns is_static() { \
     [ -f "%{_unitdir}/$1" ] && ! grep -q '^[[].nstall]' "%{_unitdir}/$1" \
 } \
@@ -65,6 +66,7 @@ unmask() { \
 \
 preset_units() { \
     local represet= \
+    local extra_opts="$3" \
     cat "$1" | while read action unit_name \
     do \
         if [ "$action" = "#" -a "$unit_name" = "Units below this line will be re-preset on package upgrade" ] \
@@ -90,15 +92,16 @@ preset_units() { \
                     # We masked this static unit before, now we unmask it. \
                     unmask "$unit_name" \
                 fi \
-                 systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || : \
+                 systemctl --no-reload $extra_opts preset "$unit_name" >/dev/null 2>&1 || : \
             else \
-                systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || : \
+                systemctl --no-reload $extra_opts preset "$unit_name" >/dev/null 2>&1 || : \
             fi \
         fi \
     done \
 } \
 \
 restore_units() { \
+    local extra_opts="$2" \
     grep '^[[:space:]]*[^#;]' "$1" | while read action unit_name \
     do \
         if is_static "$unit_name" && is_masked "$unit_name" \
@@ -107,7 +110,7 @@ restore_units() { \
             # Otherwise systemctl preset will fail badly. \
             unmask "$unit_name" \
         fi \
-        systemctl --no-reload preset "$unit_name" >/dev/null 2>&1 || : \
+        systemctl --no-reload $extra_opts preset "$unit_name" >/dev/null 2>&1 || : \
     done \
 } \
 
@@ -957,6 +960,7 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/qubes-updates-proxy-forwarder@.service
 /usr/lib/systemd/system/qubes-updates-proxy-forwarder.socket
 /usr/lib/systemd/system-preset/%qubes_preset_file
+/usr/lib/systemd/user-preset/%qubes_preset_file
 /usr/lib/modules-load.d/qubes-core.conf
 /usr/lib/systemd/system/boot.automount.d/30_qubes.conf
 /usr/lib/systemd/system/chronyd.service.d/30_qubes.conf
@@ -993,9 +997,11 @@ changed=
 if [ $1 -eq 1 ]
 then
     preset_units %{_presetdir}/%qubes_preset_file initial
+    preset_units %{%_userpresetdir}/%qubes_preset_file initial --global
     changed=true
 else
     preset_units %{_presetdir}/%qubes_preset_file upgrade
+    preset_units %{_userpresetdir}/%qubes_preset_file upgrade --global
     changed=true
     # Upgrade path - now qubes-iptables is used instead
     for svc in iptables ip6tables
@@ -1045,6 +1051,8 @@ if [ $1 -eq 0 ] ; then
     # once the Qubes OS preset file is removed.
     mkdir -p %{_rundir}/qubes-uninstall
     cp -f %{_presetdir}/%qubes_preset_file %{_rundir}/qubes-uninstall/
+    cp -f %{_userpresetdir}/%qubes_preset_file \
+        %{_rundir}/qubes-uninstall/user-%qubes_preset_file
 fi
 
 %postun systemd
@@ -1058,6 +1066,7 @@ then
     # We have a saved preset file (or more).
     # Re-preset the units mentioned there.
     restore_units %{_rundir}/qubes-uninstall/%qubes_preset_file
+    restore_units %{_rundir}/qubes-uninstall/user-%qubes_preset_file --global
     rm -rf %{_rundir}/qubes-uninstall
     changed=true
 fi

--- a/vm-systemd/75-qubes-vm.user-preset
+++ b/vm-systemd/75-qubes-vm.user-preset
@@ -1,0 +1,7 @@
+
+# Units below this line will be re-preset on package upgrade
+
+# conflicts with pulseaudio
+disable pipewire.socket
+disable pipewire.service
+disable wireplumber.service


### PR DESCRIPTION
We don't have pipewire plugin yet, and it conflicts with pulseaudio when
accessing physical audio cards (sys-audio case).

Fixes QubesOS/qubes-issues#7485
Related to QubesOS/qubes-issues#6358