### PR TITLE
Enable IPv6 Privacy Extension by default

### DIFF
--- a/network/nm-31-randomize-mac.conf
+++ b/network/nm-31-randomize-mac.conf
@@ -4,3 +4,4 @@ wifi.scan-rand-mac-address=yes
 [connection]
 wifi.cloned-mac-address=stable
 connection.stable-id=${CONNECTION}/${BOOT}
+ipv6.ip6-privacy=2


### PR DESCRIPTION
Do not leak MAC address with each IPv6 connection when stateless
autoconfiguration is used.
The base MAC address is randomized for wifi anyway, but not for
ethernet.

QubesOS/qubes-issues#938