### PR TITLE
prepare-suspend: do not disable virtual interfaces before suspend

### DIFF
--- a/qubes-rpc/prepare-suspend
+++ b/qubes-rpc/prepare-suspend
@@ -29,6 +29,9 @@ if [ "$action" = "suspend" ]; then
         if [ "$intf" = "lo" ] || [[ "$intf" = "vif"* ]]; then
             continue
         fi
+        if ! [ -e "/sys/class/net/$intf/device" ]; then
+            continue
+        fi
         if [ "$(cat "/sys/class/net/$intf/device/devtype" 2>/dev/null)" = "vif" ]; then
             continue
         fi

--- a/qubes-rpc/prepare-suspend
+++ b/qubes-rpc/prepare-suspend
@@ -29,7 +29,7 @@ if [ "$action" = "suspend" ]; then
         if [ "$intf" = "lo" ] || [[ "$intf" = "vif"* ]]; then
             continue
         fi
-        if [ "$(cat "/sys/class/net/$intf/device/devtype" 2>/dev/null$)" = "vif" ]; then
+        if [ "$(cat "/sys/class/net/$intf/device/devtype" 2>/dev/null)" = "vif" ]; then
             continue
         fi
         ip link set "$intf" down


### PR DESCRIPTION
There is no need to disable virtual (dummy) interfaces before suspend, it
matters only for physical ones. Especially, do not de-configure dummy eth1
used by Whonix, as there is nothing to turn it back on after resume.

QubesOS/qubes-issues#2044
QubesOS/qubes-issues#7404