### PR TITLE
Add support for /rw/config/rc.local-early to run commands as early as possible

### DIFF
--- a/vm-systemd/qubes-early-vm-config.sh
+++ b/vm-systemd/qubes-early-vm-config.sh
@@ -4,6 +4,10 @@
 # It happens after local-fs.target is reached
 # but before sysinit.target is reached.
 
+if [ -x /rw/config/rc.local-early ] ; then
+    /rw/config/rc.local-early
+fi
+
 # Source Qubes library.
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions

--- a/vm-systemd/qubes-early-vm-config.sh
+++ b/vm-systemd/qubes-early-vm-config.sh
@@ -4,9 +4,12 @@
 # It happens after local-fs.target is reached
 # but before sysinit.target is reached.
 
-if [ -x /rw/config/rc.local-early ] ; then
-    /rw/config/rc.local-early
-fi
+for rc in /rw/config/rc.local-early.d/*.rc /rw/config/rc.local-early; do
+    [ -f "$rc" ] || continue
+    [ -x "$rc" ] || continue
+    "$rc"
+done
+unset rc
 
 # Source Qubes library.
 # shellcheck source=init/functions


### PR DESCRIPTION
This allows to run arbitrary commands early in initialization, which is useful for things like replacing Qubes GUI packages in a specific VM.
