### PR TITLE
Allow PipeWire to run

### DIFF
--- a/vm-systemd/75-qubes-vm.user-preset
+++ b/vm-systemd/75-qubes-vm.user-preset
@@ -1,7 +1,0 @@
-
-# Units below this line will be re-preset on package upgrade
-
-# conflicts with pulseaudio
-disable pipewire.socket
-disable pipewire.service
-disable wireplumber.service


### PR DESCRIPTION
This is necessary for the PipeWire agent to be used.

To avoid causing regressions, QubesOS/qubes-gui-agent-linux#157 is needed.