### PR TITLE
Allow systemd to manage PulseAudio

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ SYSTEM_DROPINS += systemd-logind.service
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service
 
-USER_DROPINS := pulseaudio.service pulseaudio.socket
+USER_DROPINS := pulseaudio.service
 
 # Ubuntu Dropins
 ifeq ($(release),Ubuntu)

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -57,6 +57,8 @@ package_qubes-vm-core() {
         echo 'invalid $pkgver'>&2
         exit 1
     }
+    # Older versions assume systemd will not handle PulseAudio
+    conflicts=('pulseauio-qubes<4.1.27')
     release=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}
     depends=(qubes-vm-utils python python-xdg ntp iproute2
              gnome-packagekit graphicsmagick fakeroot notification-daemon dconf

--- a/debian/control
+++ b/debian/control
@@ -80,7 +80,8 @@ Conflicts:
     qubes-core-agent-linux,
     firewalld,
     qubes-core-vm-sysvinit,
-    qubes-gui-agent (<< 4.1.6-1)
+    qubes-gui-agent (<< 4.1.6-1),
+    pulseaudio-qubes (<< 4.1.27),
 Description: Qubes core agent
  This package includes various daemons necessary for qubes domU support,
  such as qrexec services.

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -154,7 +154,6 @@ usr/lib/qubes/vm-file-editor
 usr/lib/qubes/xdg-icon
 usr/lib/qubes/tinyproxy-wrapper
 usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
-usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 usr/lib/systemd/user-preset/75-qubes-vm.preset
 usr/share/glib-2.0/schemas/*
 usr/share/kde4/services/*.desktop

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -170,6 +170,8 @@ Obsoletes:  qubes-core-vm < 4.0.0
 Provides:   qubes-core-vm-doc = %{version}-%{release}
 Obsoletes:  qubes-core-vm-doc < 4.0.0
 Conflicts:  qubes-gui-agent < 4.1.6
+# older versions are not prepared for managing PulseAudio via systemd
+Conflicts:  qubes-vm-pulseaudio < 4.1.27
 BuildRequires: gcc
 BuildRequires: desktop-file-utils
 BuildRequires: pandoc
@@ -979,7 +981,6 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/tmp.mount.d/30_qubes.conf
 /usr/lib/systemd/system/sysinit.target.requires/systemd-random-seed.service
 /usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
-/usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 
 %post systemd
 

--- a/vm-systemd/user/pulseaudio.service.d/30_qubes.conf
+++ b/vm-systemd/user/pulseaudio.service.d/30_qubes.conf
@@ -1,4 +1,7 @@
 [Unit]
-#ConditionNull=false
-ConditionPathExists=/var/run/qubes-service/pulseaudio-vanilla-broken
+ConditionPathExists=/etc/pulse/qubes-default.pa
 
+[Service]
+ExecStartPre=-/usr/bin/qubesdb-read -w /qubes-audio-domain-xid
+ExecStart=
+ExecStart=/usr/bin/pulseaudio --start -n --file=/etc/pulse/qubes-default.pa --exit-idle-time=-1 --daemonize=no --log-target=journal

--- a/vm-systemd/user/pulseaudio.socket.d/30_qubes.conf
+++ b/vm-systemd/user/pulseaudio.socket.d/30_qubes.conf
@@ -1,4 +1,0 @@
-[Unit]
-#ConditionNull=false
-ConditionPathExists=/var/run/qubes-service/pulseaudio-vanilla-broken
-


### PR DESCRIPTION
This allows systemd to manage PulseAudio.  Instead of marking the
PulseAudio service as broken, override the `ExecStart=` command.