### PR TITLE
qvm-template: fallback to other mirrors

### DIFF
--- a/debian/qubes-core-agent-dom0-updates.install
+++ b/debian/qubes-core-agent-dom0-updates.install
@@ -2,4 +2,4 @@ etc/qubes-rpc/qubes.TemplateSearch
 etc/qubes-rpc/qubes.TemplateDownload
 usr/lib/qubes/qvm-template-repo-query
 usr/lib/qubes/qubes-download-dom0-updates.sh
-usr/lib/qubes/dnf-plugins/download.py
+usr/lib/qubes/dnf-plugins/downloadurl.py

--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -42,10 +42,8 @@ install:
 		upgrades-installed-check \
 		upgrades-status-notify
 	install -d -m 2775 $(DESTDIR)$(QUBESSTATEDIR)/dom0-updates
-ifneq (,$(filter $(DIST),buster bullseye bookworm bionic focal))
-	install -D -m 0644 dnf-plugin-download.py \
-		$(DESTDIR)$(QUBESLIBDIR)/dnf-plugins/download.py
-endif
+	install -D -m 0644 dnf-plugin-downloadurl.py \
+		$(DESTDIR)$(QUBESLIBDIR)/dnf-plugins/downloadurl.py
 
 install-apt:
 	install -d $(DESTDIR)$(APTCONFDIR)/sources.list.d

--- a/qubes-rpc/qvm-template-repo-query
+++ b/qubes-rpc/qvm-template-repo-query
@@ -29,11 +29,9 @@ cat > "$repodir/template.repo"
 OPTS+=("--setopt=reposdir=${repodir}")
 OPTS+=("--quiet")
 
-if [ -d '/usr/lib/qubes/dnf-plugins' ]; then
-    # use vendored 'download' dnf-plugin when available, to not require
-    # dnf-plugins-core package (not available in Debian yet)
-    OPTS+=("--setopt=pluginpath=/usr/lib/qubes/dnf-plugins")
-fi
+# use vendored 'downloadurl' dnf-plugin (fork of 'download' plugin), to print
+# all mirrors
+OPTS+=("--setopt=pluginpath=/usr/lib/qubes/dnf-plugins")
 
 if ! command -v dnf >/dev/null; then
     echo "ERROR: dnf command is missing, please use newer template for your UpdateVM to download templates." >&2
@@ -60,8 +58,7 @@ elif [ "$1" = "download" ]; then
     # downloaded - retry from the same one. If download failed and nothing was
     # downloaded, go to the next one. The intention is to retry on interrupted
     # connection, but skip mirrors that are not synchronized yet.
-    # FIXME: 'dnf download --url' prints only one URL, not all the mirrors
-    urls="$(dnf download "${OPTS[@]}" --url "$SPEC" | shuf)"
+    urls="$(dnf downloadurl "${OPTS[@]}" --url --all-mirrors "$SPEC" | shuf)"
     readarray -t urls <<<"$urls"
     downloaded=0
     status_file="$repodir/download-status.tmp"

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -812,6 +812,7 @@ rm -f %{name}-%{version}
 %dir %attr(0755,user,user) /var/lib/qubes/dom0-updates
 /usr/lib/qubes/qvm-template-repo-query
 /usr/lib/qubes/qubes-download-dom0-updates.sh
+/usr/lib/qubes/dnf-plugins/downloadurl.py
 
 %files networking
 %config(noreplace) /etc/qubes-rpc/qubes.UpdatesProxy


### PR DESCRIPTION
If download from a selected mirror failed to start at all (missing file,
connection error etc), fallback to another mirror. This requires getting
all the mirror URLs from dnf, and the default dnf's 'download' plugin
does not expose this information. Use a modified plugin for this
purpose.