### PR TITLE
qubes-rpc/nautilus: Add support for Nautilus API 4.0

### DIFF
--- a/qubes-rpc/nautilus/qvm_copy_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_copy_nautilus.py
@@ -9,9 +9,13 @@ class CopyToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
     Uses the nautilus-python api to provide a context menu with Nautilus which
     will enable the user to select file(s) to to copy to another AppVM
     '''
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
         '''Attaches context menu in Nautilus
+
+        `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
+        and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
         '''
+        files = args[-1]
         if not files:
             return
 

--- a/qubes-rpc/nautilus/qvm_dvm_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_dvm_nautilus.py
@@ -11,9 +11,13 @@ class OpenInDvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
     will enable the user to select file(s) to to open in a disposableVM
     '''
 
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
         '''Attaches context menu in Nautilus
+
+        `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
+        and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
         '''
+        files = args[-1]
         if not files:
             return
 

--- a/qubes-rpc/nautilus/qvm_move_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_move_nautilus.py
@@ -9,9 +9,13 @@ class MoveToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
     Uses the nautilus-python api to provide a context menu within Nautilus which
     will enable the user to select file(s) to to move to another AppVM
     '''
-    def get_file_items(self, window, files):
+    def get_file_items(self, *args):
         '''Attaches context menu in Nautilus
+
+        `args` will be `[files: List[Nautilus.FileInfo]]` in Nautilus 4.0 API,
+        and `[window: Gtk.Widget, files: List[Nautilus.FileInfo]]` in Nautilus 3.0 API.
         '''
+        files = args[-1]
         if not files:
             return
 


### PR DESCRIPTION
The get_file_items method of Nautilus.MenuProvider no longer take the window argument.

https://gnome.pages.gitlab.gnome.org/nautilus-python/nautilus-python-migrating-to-4.html

Fixes: QubesOS/qubes-issues#7916