### PR TITLE
qubes-rpc/nautilus: Execute external commands asynchronously

### DIFF
--- a/qubes-rpc/nautilus/qvm_copy_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_copy_nautilus.py
@@ -1,6 +1,4 @@
-import subprocess
-
-from gi.repository import Nautilus, GObject
+from gi.repository import Nautilus, GObject, GLib
 
 
 class CopyToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
@@ -35,4 +33,5 @@ class CopyToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
                # Check if file is not gone
                if not file_obj.is_gone()]
         cmd.insert(0, '/usr/lib/qubes/qvm-copy-to-vm.gnome')
-        subprocess.call(cmd)
+        pid = GLib.spawn_async(cmd)[0]
+        GLib.spawn_close_pid(pid)

--- a/qubes-rpc/nautilus/qvm_dvm_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_dvm_nautilus.py
@@ -1,7 +1,4 @@
-import os
-from subprocess import Popen
-
-from gi.repository import Nautilus, GObject
+from gi.repository import Nautilus, GObject, GLib
 
 
 class OpenInDvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
@@ -49,13 +46,10 @@ class OpenInDvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
 
             gio_file = file_obj.get_location()
 
-            # Use subprocess.DEVNULL in python >= 3.3
-            devnull = open(os.devnull, 'wb')
-            command = ['nohup', '/usr/bin/qvm-open-in-dvm']
+            command = ['/usr/bin/qvm-open-in-dvm']
             if view_only:
                 command.append('--view-only')
             command.append(gio_file.get_path())
 
-            # Use Popen instead of subprocess.call to spawn the process
-            Popen(command, stdout=devnull, stderr=devnull)
-            devnull.close()
+            pid = GLib.spawn_async(command)[0]
+            GLib.spawn_close_pid(pid)

--- a/qubes-rpc/nautilus/qvm_move_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_move_nautilus.py
@@ -1,6 +1,4 @@
-import subprocess
-
-from gi.repository import Nautilus, GObject
+from gi.repository import Nautilus, GObject, GLib
 
 
 class MoveToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
@@ -35,4 +33,5 @@ class MoveToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
                # Check if file is not gone
                if not file_obj.is_gone()]
         cmd.insert(0, '/usr/lib/qubes/qvm-move-to-vm.gnome')
-        subprocess.call(cmd)
+        pid = GLib.spawn_async(cmd)[0]
+        GLib.spawn_close_pid(pid)


### PR DESCRIPTION
Using [GLib.spawn_async](https://lazka.github.io/pgi-docs/#GLib-2.0/functions.html#GLib.spawn_async) instead of subprocess.call or subprocess.Popen 

This prevents Nautilus from getting stuck while executing external commands. And no zombies.
As far as I've tried, Nautilus 43 on fedora-37 gets stuck without closing the context menu when calling external commands synchronously, so it should also help prevent that.

I tested with debian-10 and fedora-37 templates.
