### PR TITLE
Move pulseaudio drop-in to pulseaudio-qubes package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ endif
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service
 
-USER_DROPINS := pulseaudio.service pulseaudio.socket
+USER_DROPINS :=
 
 # Ubuntu Dropins
 ifeq ($(release),Ubuntu)
@@ -138,8 +138,6 @@ install-systemd: install-init
 	install -m 0644 $(SYSTEMD_CORE_SERVICES) $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/qubes-*.timer $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/75-qubes-vm.preset $(DESTDIR)$(SYSLIBDIR)/systemd/system-preset/
-	install -D -m 0644 vm-systemd/75-qubes-vm.user-preset \
-		$(DESTDIR)$(USER_DROPIN_DIR)-preset/75-qubes-vm.preset
 	install -m 0644 vm-systemd/qubes-core.conf $(DESTDIR)$(SYSLIBDIR)/modules-load.d/
 	install -m 0644 vm-systemd/xendriverdomain.service $(DESTDIR)/etc/systemd/system/
 	install -m 0644 vm-systemd/80-qubes-vif.link $(DESTDIR)$(SYSLIBDIR)/systemd/network/

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -57,6 +57,7 @@ package_qubes-vm-core() {
         echo 'invalid $pkgver'>&2
         exit 1
     }
+    conflicts=('pulseaudio-qubes<4.2.0')
     release=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}
     depends=(qubes-vm-utils python python-xdg ntp iproute2
              gnome-packagekit graphicsmagick fakeroot notification-daemon dconf

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -221,11 +221,9 @@ configure_systemd() {
     if [ "$1" -eq 1 ]
     then
         preset_units /usr/lib/systemd/system-preset/$qubes_preset_file initial
-        preset_units /usr/lib/systemd/user-preset/$qubes_preset_file initial --global
         changed=true
     else
         preset_units /usr/lib/systemd/system-preset/$qubes_preset_file upgrade
-        preset_units /usr/lib/systemd/user-preset/$qubes_preset_file upgrade --global
         changed=true
         # Upgrade path - now qubes-iptables is used instead
         for svc in iptables ip6tables
@@ -406,8 +404,6 @@ pre_remove() {
         # once the Qubes OS preset file is removed.
         mkdir -p /run/qubes-uninstall
         cp -f /usr/lib/systemd/system-preset/$qubes_preset_file /run/qubes-uninstall/
-        cp -f /usr/lib/systemd/user-preset/$qubes_preset_file \
-            /run/qubes-uninstall/user-$qubes_preset_file
     fi
 }
 
@@ -420,7 +416,6 @@ post_remove() {
         # We have a saved preset file (or more).
         # Re-preset the units mentioned there.
         restore_units /run/qubes-uninstall/$qubes_preset_file
-        restore_units /run/qubes-uninstall/user-$qubes_preset_file --global
         rm -rf /run/qubes-uninstall
         changed=true
     fi

--- a/debian/control
+++ b/debian/control
@@ -80,7 +80,8 @@ Conflicts:
     qubes-core-agent-linux,
     firewalld,
     qubes-core-vm-sysvinit,
-    qubes-gui-agent (<< 4.1.6-1)
+    qubes-gui-agent (<< 4.1.6-1),
+    pulseaudio-qubes (<< 4.2.0-1),
 Description: Qubes core agent
  This package includes various daemons necessary for qubes domU support,
  such as qrexec services.

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -155,9 +155,6 @@ usr/lib/qubes/upgrades-status-notify
 usr/lib/qubes/vm-file-editor
 usr/lib/qubes/xdg-icon
 usr/lib/qubes/tinyproxy-wrapper
-usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
-usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
-usr/lib/systemd/user-preset/75-qubes-vm.preset
 usr/share/glib-2.0/schemas/*
 usr/share/kde4/services/*.desktop
 usr/share/keyrings/qubes-archive-keyring.gpg

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -141,13 +141,11 @@ case "${1}" in
 
             # Systemd preload-all
             preset_units /lib/systemd/system-preset/75-qubes-vm.preset initial
-            preset_units /usr/lib/systemd/user-preset/75-qubes-vm.preset initial --global
 
             # Maybe install overridden serial.conf init script
             installSerialConf
         else
             preset_units /lib/systemd/system-preset/75-qubes-vm.preset upgrade
-            preset_units /usr/lib/systemd/user-preset/75-qubes-vm.preset upgrade --global
         fi
         systemctl reenable haveged
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -173,6 +173,7 @@ Obsoletes:  qubes-core-vm < 4.0.0
 Provides:   qubes-core-vm-doc = %{version}-%{release}
 Obsoletes:  qubes-core-vm-doc < 4.0.0
 Conflicts:  qubes-gui-agent < 4.1.6
+Conflicts:  pulseaudio-qubes < 4.2.0
 BuildRequires: gcc
 BuildRequires: desktop-file-utils
 BuildRequires: pandoc
@@ -1129,7 +1130,6 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/qubes-updates-proxy-forwarder@.service
 /usr/lib/systemd/system/qubes-updates-proxy-forwarder.socket
 /usr/lib/systemd/system-preset/%qubes_preset_file
-/usr/lib/systemd/user-preset/%qubes_preset_file
 /usr/lib/modules-load.d/qubes-core.conf
 /usr/lib/systemd/system/boot.automount.d/30_qubes.conf
 /usr/lib/systemd/system/chronyd.service.d/30_qubes.conf
@@ -1154,8 +1154,6 @@ The Qubes core startup configuration for SystemD init.
 /usr/lib/systemd/system/tor@default.service.d/30_qubes.conf
 /usr/lib/systemd/system/tmp.mount.d/30_qubes.conf
 /usr/lib/systemd/system/sysinit.target.requires/systemd-random-seed.service
-/usr/lib/systemd/user/pulseaudio.service.d/30_qubes.conf
-/usr/lib/systemd/user/pulseaudio.socket.d/30_qubes.conf
 
 %post systemd
 
@@ -1166,11 +1164,9 @@ changed=
 if [ $1 -eq 1 ]
 then
     preset_units %{_presetdir}/%qubes_preset_file initial
-    preset_units %{%_userpresetdir}/%qubes_preset_file initial --global
     changed=true
 else
     preset_units %{_presetdir}/%qubes_preset_file upgrade
-    preset_units %{_userpresetdir}/%qubes_preset_file upgrade --global
     changed=true
     # Upgrade path - now qubes-iptables is used instead
     for svc in iptables ip6tables
@@ -1220,8 +1216,6 @@ if [ $1 -eq 0 ] ; then
     # once the Qubes OS preset file is removed.
     mkdir -p %{_rundir}/qubes-uninstall
     cp -f %{_presetdir}/%qubes_preset_file %{_rundir}/qubes-uninstall/
-    cp -f %{_userpresetdir}/%qubes_preset_file \
-        %{_rundir}/qubes-uninstall/user-%qubes_preset_file
 fi
 
 %postun systemd
@@ -1235,7 +1229,6 @@ then
     # We have a saved preset file (or more).
     # Re-preset the units mentioned there.
     restore_units %{_rundir}/qubes-uninstall/%qubes_preset_file
-    restore_units %{_rundir}/qubes-uninstall/user-%qubes_preset_file --global
     rm -rf %{_rundir}/qubes-uninstall
     changed=true
 fi

--- a/vm-systemd/75-qubes-vm.user-preset
+++ b/vm-systemd/75-qubes-vm.user-preset
@@ -1,7 +1,0 @@
-
-# Units below this line will be re-preset on package upgrade
-
-# conflicts with pulseaudio
-disable pipewire.socket
-disable pipewire.service
-disable wireplumber.service


### PR DESCRIPTION
Move it together with related preset file that disables conflicting
pipewire.

That was the last user service drop-in file in this package, but leave
makefile rules in place in case some other will be added.

This is an alternative to #389