### PR TITLE
qvm-connect-tcp: print usage on invalid parameters

### DIFF
--- a/network/qvm-connect-tcp
+++ b/network/qvm-connect-tcp
@@ -35,5 +35,6 @@ if check_port "$PORT" && check_port "$LOCALPORT"; then
     sudo socat TCP-LISTEN:"$LOCALPORT",reuseaddr,fork EXEC:"qrexec-client-vm \'$DOMAIN\' qubes.ConnectTCP+$PORT" &
 else
     echo "Invalid port provided"
+    print_usage
     exit 1
 fi


### PR DESCRIPTION
This also handles things like `qvm-connect-tcp --help`, which are otherwise met with a very unhelpful error message.