### PR TITLE
Handle dom0 rpmdb in /usr/lib/sysimage/rpm too

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -73,11 +73,15 @@ fi
 mkdir -p $DOM0_UPDATES_DIR/etc
 
 # Check if we need to copy rpmdb somewhere else
+DOM0_DBPATH=/var/lib/rpm
+if [ -d "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm" ] && ! [ -L "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm" ]; then
+    DOM0_DBPATH=/usr/lib/sysimage/rpm
+fi
 DBPATH=$(rpm --eval '%{_dbpath}')
-if [ ! "$DBPATH" = "/var/lib/rpm" ]; then
+if [ ! "$DBPATH" = "$DOM0_DBPATH" ]; then
     mkdir -p "$DOM0_UPDATES_DIR$DBPATH"
     rm -rf -- "$DOM0_UPDATES_DIR$DBPATH"
-    cp -r "$DOM0_UPDATES_DIR/var/lib/rpm" "$DOM0_UPDATES_DIR$DBPATH"
+    cp -r "$DOM0_UPDATES_DIR$DOM0_DBPATH" "$DOM0_UPDATES_DIR$DBPATH"
 fi
 # Rebuild rpm database in case of different rpm version
 rm -f -- "$DOM0_UPDATES_DIR$DBPATH"/__*


### PR DESCRIPTION
When dom0 gets updated to newer Fedora, its rpmdb is in
/usr/lib/sysimage/rpm. Handle this case by checking for this directory
too - and check if that's really a directory, not a symlink to one.

QubesOS/qubes-issues#6982