### PR TITLE
dom0-updates: force refreshing sqlite rpmdb if legacy one is newer

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -72,6 +72,15 @@ fi
 
 mkdir -p $DOM0_UPDATES_DIR/etc
 
+# remove converted sqlite db if legacy db is newer, to force conversion again
+# legacy db could be only in the /var/lib/rpm location, but sqlite could be in any
+if [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite" ]; then
+    rm -f -- "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite"*
+elif [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm/rpmdb.sqlite" ]; then
+    # remove the whole directory, to make the logic below happy
+    rm -rf -- "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm"
+fi
+
 # Check if we need to copy rpmdb somewhere else
 DOM0_DBPATH=/var/lib/rpm
 if [ -d "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm" ] && ! [ -L "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm" ]; then


### PR DESCRIPTION
This is especially relevant for older dom0 (in R4.1) - otherwise once
converted rpmdb won't be updated in subsequent calls. But add it to
newer systems too, in case similar logic will be necessary in the future
too.

Fixes: e7aed41 "Handle dom0 rpmdb in /usr/lib/sysimage/rpm too"
QubesOS/qubes-issues#6982