### PR TITLE
Do not hard-code `user`

### DIFF
--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -6,15 +6,17 @@ qubes_preset_file="75-qubes-vm.preset"
 ###########################
 
 update_default_user() {
+    local user
     # Make sure there is a qubes group
     groupadd --force --system --gid 98 qubes
 
+    user=$(qubesdb-read /default-user) || user=user
     # Archlinux bash version has a 'bug' when running su -c, /etc/profile is not loaded because bash consider there is no interactive pty when running 'su - user -c' or something like this.
     # See https://bugs.archlinux.org/task/31831
-    id -u 'user' >/dev/null 2>&1 || {
-        useradd --user-group --create-home --shell /bin/bash user
+    id -u -- "$user" >/dev/null 2>&1 || {
+        useradd --user-group --create-home --shell /bin/bash -- "$user"
     }
-    usermod -a --groups qubes user
+    usermod -a --groups qubes -- "$user"
 }
 
 ## arg 1:  the new package version
@@ -339,7 +341,7 @@ post_install() {
         cp /etc/init/serial.conf /var/lib/qubes/serial.orig
     fi
 
-    chgrp user /var/lib/qubes/dom0-updates
+    chgrp qubes /var/lib/qubes/dom0-updates
 
     # Remove most of the udev scripts to speed up the VM boot time
     # Just leave the xen* scripts, that are needed if this VM was

--- a/debian/qubes-core-agent-caja.install
+++ b/debian/qubes-core-agent-caja.install
@@ -1,2 +1,1 @@
 usr/share/caja-python/extensions/*
-usr/lib/qubes/qvm_caja_bookmark.sh

--- a/debian/qubes-core-agent-thunar.postinst
+++ b/debian/qubes-core-agent-thunar.postinst
@@ -31,11 +31,6 @@ case "${1}" in
           #shellcheck disable=SC2016
           sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' /etc/xdg/Thunar/uca.xml
         fi
-        if [ -f /home/user/.config/Thunar/uca.xml ] ; then
-          cp -p /home/user/.config/Thunar/uca.xml /home/user/.config/Thunar/uca.xml.bak
-          #shellcheck disable=SC2016
-          sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' /home/user/.config/Thunar/uca.xml
-        fi
         ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/debian/qubes-core-agent-thunar.postrm
+++ b/debian/qubes-core-agent-thunar.postrm
@@ -41,10 +41,6 @@ if [ "${1}" = "remove" ] || [ "${1}" = "upgrade" ] ; then
     mv /etc/xdg/Thunar/uca.xml /etc/xdg/Thunar/uca.xml.uninstall
     mv /etc/xdg/Thunar/uca.xml.bak /etc/xdg/Thunar/uca.xml
   fi
-  if [ -f /home/user/.config/Thunar/uca.xml ] && [ -f /home/user/.config/Thunar/uca.xml.bak ]; then
-    mv /home/user/.config/Thunar/uca.xml /home/user/.config/Thunar/uca.xml.uninstall
-    mv /home/user/.config/Thunar/uca.xml.bak /home/user/.config/Thunar/uca.xml
-  fi
 fi
 
 # dh_installdeb will replace this with shell code automatically

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -149,7 +149,7 @@ case "${1}" in
         fi
         systemctl reenable haveged || :
 
-        chgrp user /var/lib/qubes/dom0-updates
+        chgrp qubes /var/lib/qubes/dom0-updates
 
         debug "UPDATE..."
         # disable some Upstart services
@@ -186,8 +186,8 @@ case "${1}" in
             rm /etc/systemd/system/multi-user.target.wants/qubes-mount-home.service
         fi
 
-        if ! dpkg-statoverride --list /var/lib/qubes/dom0-updates >/dev/null 2>&1; then
-            dpkg-statoverride --update --add user user 775 /var/lib/qubes/dom0-updates
+        if ! dpkg-statoverride --list /var/lib/qubes/dom0-updates >/dev/null 2>&1 && { user=$(qubesdb-read /default-user) || user=user;} ; then
+            dpkg-statoverride --update --add -- "$user" qubes 775 /var/lib/qubes/dom0-updates
         fi
 
         glib-compile-schemas /usr/share/glib-2.0/schemas || true

--- a/debian/qubes-core-agent.preinst
+++ b/debian/qubes-core-agent.preinst
@@ -32,6 +32,7 @@ set -e
 #    For details, see http://www.debian.org/doc/debian-policy/ or
 # https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html or
 # the debian-policy package
+user=$(qubesdb-read /default-user) || user=user
 
 if [ "$1" = "install" ] ; then
     # --------------------------------------------------------------------------
@@ -43,13 +44,13 @@ if [ "$1" = "install" ] ; then
     # --------------------------------------------------------------------------
     # User add / modifications
     # --------------------------------------------------------------------------
-    id -u 'user' >/dev/null 2>&1 || {
-        useradd --user-group --create-home --shell /bin/bash user
+    id -u -- "$user" >/dev/null 2>&1 || {
+        useradd --user-group --create-home --shell /bin/bash -- "$user"
     }
     id -u 'tinyproxy' >/dev/null 2>&1 || {
         useradd --user-group --system --no-create-home --home /run/tinyproxy --shell /bin/false tinyproxy
     }
-    usermod --lock --append --groups qubes user
+    usermod --lock --append --groups qubes -- "$user"
 
     # --------------------------------------------------------------------------
     # Remove `mesg` from root/.profile?
@@ -71,8 +72,8 @@ if [ "$1" = "upgrade" ] ; then
     fi
     ## Allow passwordless login for user "user" (when using 'sudo xl console').
     ## https://github.com/QubesOS/qubes-issues/issues/1130
-    if grep -q '^user:\!:' /etc/shadow ; then
-        passwd user --delete >/dev/null || true
+    if grep -q "^$user:!:" /etc/shadow ; then
+        passwd --delete -- "$user" >/dev/null || true
     fi
 fi
 

--- a/qubes-rpc/caja/Makefile
+++ b/qubes-rpc/caja/Makefile
@@ -6,4 +6,3 @@ QUBESLIBDIR ?= /usr/lib/qubes
 install:
 	install -d $(DESTDIR)$(CAJAPYEXTDIR)
 	install -t $(DESTDIR)$(CAJAPYEXTDIR) -m 0644 *.py
-	install -t $(DESTDIR)$(QUBESLIBDIR) -m 0755 *.sh

--- a/qubes-rpc/caja/qvm_caja_bookmark.sh
+++ b/qubes-rpc/caja/qvm_caja_bookmark.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ ! -e ~/.config/gtk-3.0/qubes-incoming-bookmark-created ]
-then
-  echo "file:///home/user/QubesIncoming" >> ~/.config/gtk-3.0/bookmarks
-  touch ~/.config/gtk-3.0/qubes-incoming-bookmark-created
-fi

--- a/qubes-rpc/dvm2.h
+++ b/qubes-rpc/dvm2.h
@@ -1,3 +1,2 @@
 #define DVM_FILENAME_SIZE 256
-#define DVM_SPOOL "/home/user/.dvmspool"
 #define DVM_VIEW_ONLY_PREFIX "view-only-"

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -396,11 +396,12 @@ make -C doc manpages
 
 %pre
 # Make sure there is a qubes group
+set -e
+user=$(qubesdb-read /default-user) || user=user
 groupadd --force --system --gid 98 qubes
-id -u 'user' >/dev/null 2>&1 || {
-  useradd --user-group --create-home --shell /bin/bash user
-}
-usermod -a --groups qubes user
+id -u -- "$user" >/dev/null 2>&1 ||
+  useradd --user-group --create-home --shell /bin/bash -- "$user"
+usermod -a -L --groups qubes -- "$user"
 
 if [ "$1" !=  1 ] ; then
 # do this whole %%pre thing only when updating for the first time...
@@ -411,8 +412,6 @@ mkdir -p /var/lib/qubes
 if [ -e /etc/fstab ] ; then
 mv /etc/fstab /var/lib/qubes/fstab.orig
 fi
-
-usermod -L user
 
 %pre passwordless-root
 
@@ -487,7 +486,7 @@ for F in plymouth-shutdown prefdm splash-manager start-ttys tty ; do
     fi
 done
 
-chgrp user /var/lib/qubes/dom0-updates
+chgrp qubes /var/lib/qubes/dom0-updates
 
 # Remove old firmware updates link
 if [ -L /lib/firmware/updates ]; then
@@ -997,7 +996,7 @@ rm -f %{name}-%{version}
 %files dom0-updates
 %config(noreplace) /etc/qubes-rpc/qubes.TemplateSearch
 %config(noreplace) /etc/qubes-rpc/qubes.TemplateDownload
-%dir %attr(0755,user,user) /var/lib/qubes/dom0-updates
+%dir %attr(0775,root,qubes) /var/lib/qubes/dom0-updates
 /usr/lib/qubes/qvm-template-repo-query
 /usr/lib/qubes/qubes-download-dom0-updates.sh
 /usr/lib/qubes/dnf-plugins/downloadurl.py

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -979,7 +979,6 @@ rm -f %{name}-%{version}
 /usr/share/caja-python/extensions/qvm_copy_caja.py*
 /usr/share/caja-python/extensions/qvm_move_caja.py*
 /usr/share/caja-python/extensions/qvm_dvm_caja.py*
-/usr/lib/qubes/qvm_caja_bookmark.sh
 %endif
 
 %files nautilus

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -637,10 +637,6 @@ if [ "$1" = 1 ]; then
     cp -p /etc/xdg/Thunar/uca.xml{,.bak}
     sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' /etc/xdg/Thunar/uca.xml
   fi
-  if [ -f /home/user/.config/Thunar/uca.xml ] ; then
-    cp -p /home/user/.config/Thunar/uca.xml{,.bak}
-    sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' /home/user/.config/Thunar/uca.xml
-  fi
 fi
 
 %preun
@@ -766,10 +762,6 @@ if [ "$1" = 0 ]; then
   if [ -f /etc/xdg/Thunar/uca.xml ] ; then
     mv /etc/xdg/Thunar/uca.xml{,.uninstall}
     mv /etc/xdg/Thunar/uca.xml{.bak,}
-  fi
-  if [ -f /home/user/.config/Thunar/uca.xml ] ; then
-    mv /home/user/.config/Thunar/uca.xml{,.uninstall}
-    mv /home/user/.config/Thunar/uca.xml{.bak,}
   fi
 fi
 


### PR DESCRIPTION
Qubes VMs can have any default user permitted by the operating system, provided that it can fit in qubesd.