### PR TITLE
Xen hotplug scripts should be initrc_exec_t

### DIFF
--- a/selinux/qubes-misc.fc
+++ b/selinux/qubes-misc.fc
@@ -8,6 +8,7 @@ define(`slash_run',`dnl
 /usr/lib/qubes(/.*)?                    gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/qubes/init(/.*)?            -d gen_context(system_u:object_r:etc_t,s0)
 /usr/lib/qubes/init(/.*)?            -- gen_context(system_u:object_r:initrc_exec_t,s0)
+/etc/xen/scripts/[!/]+               -- gen_context(system_u:object_r:initrc_exec_t,s0)
 /usr/lib/qubes/network-manager-prepare-conf-dir -- gen_context(system_u:object_r:bin_t,s0)
 slash_run(`qubes(/.*)?',`qubes_var_run')
 slash_run(`qubes-service',`initrc_var_run',`-d')


### PR DESCRIPTION
This makes them unconfined while ensuring that programs they spawn have the correct (possibly confined) contexts.

Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Fixes: QubesOS/qubes-issues#8155