### PR TITLE
Unify and improve wording on copy/move to other qube

### DIFF
--- a/qubes-rpc/caja/qvm_copy_caja.py
+++ b/qubes-rpc/caja/qvm_copy_caja.py
@@ -16,7 +16,7 @@ class CopyToAppvmItemExtension(GObject.GObject, Caja.MenuProvider):
             return
 
         menu_item = Caja.MenuItem(name='QubesMenuProvider::CopyToAppvm',
-                                  label='Copy To Other AppVM...',
+                                  label='Copy to other qube...',
                                   tip='',
                                   icon='')
 

--- a/qubes-rpc/caja/qvm_dvm_caja.py
+++ b/qubes-rpc/caja/qvm_dvm_caja.py
@@ -18,14 +18,14 @@ class OpenInDvmItemExtension(GObject.GObject, Caja.MenuProvider):
             return
 
         menu_item1 = Caja.MenuItem(name='QubesMenuProvider::OpenInDvm',
-                                   label='Edit In DisposableVM',
+                                   label='Edit in disposable qube',
                                    tip='',
                                    icon='')
 
         menu_item1.connect('activate', self.on_menu_item_clicked, files)
 
         menu_item2 = Caja.MenuItem(name='QubesMenuProvider::ViewInDvm',
-                                   label='View In DisposableVM',
+                                   label='View in disposable qube',
                                    tip='',
                                    icon='')
 

--- a/qubes-rpc/caja/qvm_move_caja.py
+++ b/qubes-rpc/caja/qvm_move_caja.py
@@ -16,7 +16,7 @@ class MoveToAppvmItemExtension(GObject.GObject, Caja.MenuProvider):
             return
 
         menu_item = Caja.MenuItem(name='QubesMenuProvider::MoveToAppvm',
-                                  label='Move To Other AppVM...',
+                                  label='Move to other qube...',
                                   tip='',
                                   icon='')
 

--- a/qubes-rpc/kde/qvm-copy.desktop
+++ b/qubes-rpc/kde/qvm-copy.desktop
@@ -6,5 +6,5 @@ X-KDE-ServiceTypes=KonqPopupMenu/Plugin,inode/directory,all/allfiles
 [Desktop Action QvmCopy]
 Exec=/usr/lib/qubes/qvm-copy-to-vm.kde %U
 Icon=kget
-Name=Copy To VM
+Name=Copy to other qube
 

--- a/qubes-rpc/kde/qvm-dvm.desktop
+++ b/qubes-rpc/kde/qvm-dvm.desktop
@@ -6,10 +6,10 @@ X-KDE-ServiceTypes=KonqPopupMenu/Plugin,all/allfiles
 [Desktop Action QvmDvm]
 Exec=/usr/bin/qvm-open-in-dvm %U
 Icon=kget
-Name=Edit In DisposableVM
+Name=Edit in disposable qube
 
 [Desktop Action QvmViewDvm]
 Exec=/usr/bin/qvm-open-in-dvm --view-only %U
 Icon=kget
-Name=View In DisposableVM
+Name=View in disposable qube
 

--- a/qubes-rpc/kde/qvm-move.desktop
+++ b/qubes-rpc/kde/qvm-move.desktop
@@ -6,5 +6,5 @@ X-KDE-ServiceTypes=KonqPopupMenu/Plugin,inode/directory,all/allfiles
 [Desktop Action QvmMove]
 Exec=/usr/lib/qubes/qvm-move-to-vm.kde %U
 Icon=kget
-Name=Move To VM
+Name=Move to other qube
 

--- a/qubes-rpc/nautilus/qvm_copy_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_copy_nautilus.py
@@ -18,7 +18,7 @@ class CopyToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
             return
 
         menu_item = Nautilus.MenuItem(name='QubesMenuProvider::CopyToAppvm',
-                                      label='Copy To Other AppVM...',
+                                      label='Copy to other qube...',
                                       tip='',
                                       icon='')
 

--- a/qubes-rpc/nautilus/qvm_dvm_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_dvm_nautilus.py
@@ -19,14 +19,14 @@ class OpenInDvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
             return
 
         menu_item1 = Nautilus.MenuItem(name='QubesMenuProvider::OpenInDvm',
-                                      label='Edit In DisposableVM',
+                                      label='Edit in disposable qube',
                                       tip='',
                                       icon='')
 
         menu_item1.connect('activate', self.on_menu_item_clicked, files)
 
         menu_item2 = Nautilus.MenuItem(name='QubesMenuProvider::ViewInDvm',
-                                      label='View In DisposableVM',
+                                      label='View in disposable qube',
                                       tip='',
                                       icon='')
 

--- a/qubes-rpc/nautilus/qvm_move_nautilus.py
+++ b/qubes-rpc/nautilus/qvm_move_nautilus.py
@@ -18,7 +18,7 @@ class MoveToAppvmItemExtension(GObject.GObject, Nautilus.MenuProvider):
             return
 
         menu_item = Nautilus.MenuItem(name='QubesMenuProvider::MoveToAppvm',
-                                      label='Move To Other AppVM...',
+                                      label='Move to other qube...',
                                       tip='',
                                       icon='')
 

--- a/qubes-rpc/qopen-in-vm.c
+++ b/qubes-rpc/qopen-in-vm.c
@@ -73,8 +73,8 @@ void recv_file_nowrite(const char *fname)
         return;
     }
     if (asprintf(&errmsg,
-         "The file %s has been edited in Disposable VM and the modified content has been received, "
-         "but this file is in nonwritable directory and thus cannot be modified safely. The edited file has been "
+         "The file %s has been edited in a disposable qube and the modified content has been received, "
+         "but this file is in read-only directory and thus cannot be modified safely. The edited file has been "
          "saved to %s", fname, tempfile) != -1)
         gui_nonfatal(errmsg);
 }

--- a/qubes-rpc/thunar/qvm-actions.sh
+++ b/qubes-rpc/thunar/qvm-actions.sh
@@ -34,19 +34,19 @@ case "$action" in
         for file in "$@"
         do
             #shellcheck disable=SC2016
-            qvm-open-in-vm '$default' "$file" | zenity --notification --text "Opening $file in VM..." --timeout 3 &
+            qvm-open-in-vm '$default' "$file" | zenity --notification --text "Opening $file in qube..." --timeout 3 &
         done
         ;;
     opendvm)
         for file in "$@"
         do
-            qvm-open-in-dvm "$file" | zenity --notification --text "Opening $file in DisposableVM..." --timeout 3 &
+            qvm-open-in-dvm "$file" | zenity --notification --text "Opening $file in disposable qube..." --timeout 3 &
         done
         ;;
     viewdvm)
         for file in "$@"
         do
-            qvm-open-in-dvm --view-only "$file" | zenity --notification --text "Opening $file in DisposableVM..." --timeout 3 &
+            qvm-open-in-dvm --view-only "$file" | zenity --notification --text "Opening $file in disposable qube..." --timeout 3 &
         done
         ;;
     *)

--- a/qubes-rpc/thunar/uca_qubes.xml
+++ b/qubes-rpc/thunar/uca_qubes.xml
@@ -1,6 +1,6 @@
 <action>
 	<icon>stock_folder-copy</icon>
-	<name>Copy to VM</name>
+	<name>Copy to other qube</name>
 	<unique-id>1507455450991127-4</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh copy %F</command>
 	<description></description>
@@ -14,7 +14,7 @@
 </action>
 <action>
 	<icon>stock_folder-move</icon>
-	<name>Move to VM</name>
+	<name>Move to other qube</name>
 	<unique-id>1507455437157027-3</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh move %F</command>
 	<description></description>
@@ -28,7 +28,7 @@
 </action>
 <action>
 	<icon>document-open</icon>
-	<name>Open in VM</name>
+	<name>Open in other qube</name>
 	<unique-id>1507455471075266-5</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh openvm %F</command>
 	<description></description>
@@ -41,7 +41,7 @@
 </action>
 <action>
 	<icon>gtk-convert</icon>
-	<name>Convert in DisposableVM</name>
+	<name>Convert in disposable qube</name>
 	<unique-id>1507455488971315-6</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh pdf %F</command>
 	<description></description>
@@ -50,7 +50,7 @@
 </action>
 <action>
 	<icon>gtk-convert</icon>
-	<name>Convert in DisposableVM</name>
+	<name>Convert in disposable qube</name>
 	<unique-id>1507455503129941-7</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh img %F</command>
 	<description></description>
@@ -59,7 +59,7 @@
 </action>
 <action>
 	<icon>document-open</icon>
-	<name>Edit in DisposableVM</name>
+	<name>Edit in disposable qube</name>
 	<unique-id>1507455559234996-8</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh opendvm %F</command>
 	<description></description>
@@ -72,7 +72,7 @@
 </action>
 <action>
 	<icon>document-open</icon>
-	<name>View in DisposableVM</name>
+	<name>View in disposable qube</name>
 	<unique-id>1507455559234997-9</unique-id>
 	<command>/usr/lib/qubes/qvm-actions.sh viewdvm %F</command>
 	<description></description>


### PR DESCRIPTION
Use qube instead of VM/AppVM, use the same wording everywhere and move from every-word-capitized to sentence capitalization

references QubesOS/qubes-issues#1015
references https://github.com/QubesOS/qubes-desktop-linux-manager/pull/150