### PR TITLE
Update archlinux python version dependency to <3.12

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -82,7 +82,7 @@ package_qubes-vm-core() {
         pacman-contrib
         parted
         # Block updating if there is a major python update as the python API will be in the wrong PYTHONPATH
-        'python<3.11'
+        'python<3.12'
     )
     optdepends=(gnome-keyring gnome-settings-daemon python-caja python-nautilus gpk-update-viewer qubes-vm-networking qubes-vm-keyring)
     install="archlinux/PKGBUILD.install"


### PR DESCRIPTION
Update the python dependency for ArchLinux.

Related to https://github.com/QubesOS/qubes-issues/issues/8170