### PR TITLE
Disable blueman applet by default

### DIFF
--- a/app-menu/qubes-session-autostart
+++ b/app-menu/qubes-session-autostart
@@ -78,7 +78,7 @@ def process_autostart(environments):
                 else:
                     entry = DesktopEntry(entry_path)
                 if entry_should_be_started(entry, environments):
-                    launch(entry_path, wait=False)
+                    launch(entry, wait=False)
             except Exception as e:
                 print("Failed to process '{}': {}".format(
                     entry_name, str(e)),

--- a/autostart-dropins/blueman.desktop
+++ b/autostart-dropins/blueman.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+Exec=/usr/lib/qubes/qvm-service-wrapper blueman blueman-applet

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -145,6 +145,7 @@ usr/lib/qubes/qvm-copy-to-vm.gnome
 usr/lib/qubes/qvm-copy-to-vm.kde
 usr/lib/qubes/qvm-move-to-vm.gnome
 usr/lib/qubes/qvm-move-to-vm.kde
+usr/lib/qubes/qvm-service-wrapper
 usr/lib/qubes/resize-rootfs
 usr/lib/qubes/tar2qfile
 usr/lib/qubes/update-proxy-configs

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -1,6 +1,8 @@
 BINDIR ?= /usr/bin
 DATADIR ?= /usr/share
 SYSLIBDIR ?= /lib
+LIBDIR ?= /usr/lib
+QUBESLIBDIR := $(LIBDIR)/qubes
 UDEVRULESDIR := $(SYSLIBDIR)/udev/rules.d
 QUBESDATADIR := $(DATADIR)/qubes
 QUBESMIMEDIR := $(QUBESDATADIR)/xdg-override
@@ -39,6 +41,8 @@ install:
 	umask 022 && cp -r applications mime '$(DESTDIR)$(QUBESMIMEDIR)'
 	install -m 0755 -d $(DESTDIR)$(BINDIR)
 	install -m 0755 -t $(DESTDIR)$(BINDIR) qvm-features-request
+	install -m 0755 -d $(DESTDIR)$(QUBESLIBDIR)
+	install -m 0755 -t $(DESTDIR)$(QUBESLIBDIR) qvm-service-wrapper
 
 marker-vm: marker-vm.in
 	printf "$(VERSION)" | cut -f 1,2 -d . | cat $< - > marker-vm

--- a/misc/qvm-service-wrapper
+++ b/misc/qvm-service-wrapper
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Start an application given as $2 only if qvm-service $1 is enabled
+
+service="$1"
+shift
+if ! [ -r "/run/qubes-service/$service" ]; then
+    echo "Not starting '$1', qvm-service '$service' is not enabled" >&2
+    exit 0
+fi
+
+exec "$@"

--- a/qubes-rpc/post-install.d/10-qubes-core-agent-features.sh
+++ b/qubes-rpc/post-install.d/10-qubes-core-agent-features.sh
@@ -21,6 +21,10 @@ fi
 
 qvm-features-request supported-service.meminfo-writer=1
 
+if [ -e /etc/xdg/autostart/blueman.desktop ]; then
+    qvm-features-request supported-service.blueman=1
+fi
+
 # native services plugged into qubes-services with systemd drop-ins, list them
 # only when actual service is installed
 advertise_systemd_service() {

--- a/qubesagent/xdg.py
+++ b/qubesagent/xdg.py
@@ -38,7 +38,10 @@ def make_launcher(filename, dropins_dir=DROPINS_DIR):
         return Gio.DesktopAppInfo.new_from_filename(filename)
 
     desktop_entry = load_desktop_entry_with_dropins(filename, dropins)
+    return make_launcher_from_entry(desktop_entry)
 
+
+def make_launcher_from_entry(desktop_entry):
     data = GLib.Bytes(ini_to_string(desktop_entry).encode('utf-8'))
     keyfile = GLib.KeyFile()
     keyfile.load_from_bytes(data, 0)
@@ -77,9 +80,12 @@ def dbus_name_change(loop, service_id, name, old_owner, new_owner):
         loop.quit()
 
 
-def launch(filename, *files, **kwargs):
+def launch(filename_or_entry, *files, **kwargs):
     wait = kwargs.pop('wait', True)
-    launcher = make_launcher(filename)
+    if isinstance(filename_or_entry, str):
+        launcher = make_launcher(filename_or_entry)
+    else:
+        launcher = make_launcher_from_entry(filename_or_entry)
     loop = None
     try:
         import dbus

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -909,6 +909,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/qvm-copy-to-vm.kde
 /usr/lib/qubes/qvm-move-to-vm.gnome
 /usr/lib/qubes/qvm-move-to-vm.kde
+/usr/lib/qubes/qvm-service-wrapper
 /usr/lib/qubes/tar2qfile
 /usr/lib/qubes/vm-file-editor
 /usr/lib/qubes/xdg-icon


### PR DESCRIPTION
It is useless without bluetooth controller (most qubes), and without loaded
rfkill module (also not useful in most cases) it crashes on start. See
linked issue for details.

It is still possible to enable it via 'blueman' qvm-service.

Fixes QubesOS/qubes-issues#8161