### PR TITLE
Remount /lib/modules in early boot

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -88,6 +88,7 @@ lib/systemd/system/qubes-mount-dirs.service
 lib/systemd/system/qubes-rootfs-resize.service
 lib/systemd/system/qubes-sysinit.service
 lib/systemd/system/qubes-update-check.service
+lib/systemd/system/qubes-remount-lib-modules.service
 lib/systemd/system/qubes-update-check.timer
 lib/systemd/system/qubes-updates-proxy-forwarder@.service
 lib/systemd/system/qubes-updates-proxy-forwarder.socket
@@ -129,6 +130,7 @@ usr/lib/qubes/init/misc-post-stop.sh
 usr/lib/qubes/init/misc-post.sh
 usr/lib/qubes/init/mount-dirs.sh
 usr/lib/qubes/init/qubes-early-vm-config.sh
+usr/lib/qubes/init/qubes-remount-lib-modules.sh
 usr/lib/qubes/init/qubes-random-seed.sh
 usr/lib/qubes/init/qubes-sysinit.sh
 usr/lib/qubes/init/resize-rootfs-if-needed.sh

--- a/init/qubes-remount-lib-modules.sh
+++ b/init/qubes-remount-lib-modules.sh
@@ -1,0 +1,16 @@
+#!/bin/sh --
+
+# This may fail, but that is harmless
+umount --lazy /run/modules /lib/modules 2> /dev/null
+
+# Nothing else may fail
+set -eu
+
+# Make sure permissions are correct
+umask 0022
+mkdir -p /run/modules /lib/.modules_work
+mount -n -t ext3 -o ro /dev/xvdd /run/modules
+# Mount the overlayfs.  Disable indexing to avoid a mount failure
+# if indexing is on by default in the kernel configuration.
+mount -t overlay libmodules /lib/modules -o lowerdir=/run/modules,upperdir=/lib/modules,workdir=/lib/.modules_work,index=off,redirect_dir=on
+umount /run/modules

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -934,6 +934,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/init/qubes-sysinit.sh
 /usr/lib/qubes/init/resize-rootfs-if-needed.sh
 /usr/lib/qubes/init/setup-rw.sh
+/usr/lib/qubes/init/qubes-remount-lib-modules.sh
 /usr/lib/qubes/init/setup-rwdev.sh
 %dir /usr/lib/qubes-bind-dirs.d
 /usr/lib/qubes-bind-dirs.d/30_cron.conf
@@ -1021,6 +1022,7 @@ rm -f %{name}-%{version}
 %_unitdir/qubes-network-uplink.service
 %_unitdir/qubes-network-uplink@.service
 %_unitdir/qubes-updates-proxy.service
+%_unitdir/qubes-remount-lib-modules.service
 /usr/lib/systemd/network/80-qubes-vif.link
 /usr/lib/qubes/init/network-proxy-setup.sh
 /usr/lib/qubes/init/network-proxy-stop.sh

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -112,6 +112,7 @@ enable module-load-dummy-psu.service
 enable module-load-dummy-backlight.service
 enable qubes-psu-client@.service default sys-usb
 enable dev-xvdc1-swap.service
+enable qubes-remount-lib-modules.service
 
 # Disable useless Xen services in Qubes VM
 disable xenstored.service

--- a/vm-systemd/qubes-remount-lib-modules.service
+++ b/vm-systemd/qubes-remount-lib-modules.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Remount /lib/modules for SELinux
+DefaultDependencies=no
+Conflicts=shutdown.target
+Before=shutdown.target
+Before=qubes-bind-dirs.service rw.mount home.mount qubes-gui-agent.service qubes-qrexec-agent.service
+# This runs *very* early in boot, before even local file systems or udev
+Before=systemd-modules-load.service local-fs-pre.target systemd-udevd.service
+ConditionPathExists=/dev/xvdd
+ConditionKernelVersion=*qubes*
+ConditionSecurity=selinux
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/qubes/init/qubes-remount-lib-modules.sh
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This unbreaks writing to /lib/modules with SELinux enforcing.

Reported-by: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
Fixes: QubesOS/qubes-issues#8144