### PR TITLE
qubes.WaitForSession: no need to specify machine

### DIFF
--- a/qubes-rpc/qubes.WaitForSession
+++ b/qubes-rpc/qubes.WaitForSession
@@ -7,6 +7,6 @@ do
     sleep 0.1
 done
 
-systemctl --machine="$USERNAME"@.host --user --wait --quiet is-system-running
+systemctl --user --wait --quiet is-system-running
 
 exit 0


### PR DESCRIPTION
Closes https://github.com/QubesOS/qubes-issues/issues/8205