### PR TITLE
debian: fix postinst script in chroot

### DIFF
--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -94,7 +94,7 @@ preset_units () {
         fi
     done < "$1"
 
-    systemctl daemon-reload
+    systemctl daemon-reload >/dev/null 2>&1 || :
 }
 
 installSerialConf () {
@@ -147,7 +147,7 @@ case "${1}" in
         else
             preset_units /lib/systemd/system-preset/75-qubes-vm.preset upgrade
         fi
-        systemctl reenable haveged
+        systemctl reenable haveged || :
 
         chgrp user /var/lib/qubes/dom0-updates
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -232,6 +232,7 @@ DNF plugin for Qubes specific post-installation actions:
  * refresh applications shortcut list
 %endif
 
+%if 0%{?rhel} != 7
 %package caja
 Summary:    Qubes integration for Caja
 Requires:   qubes-core-agent = %{version}
@@ -240,6 +241,7 @@ Conflicts:  qubes-core-vm < 4.0.0
 
 %description caja
 Caja addons for inter-VM file copy/move/open.
+%endif
 
 %package nautilus
 Summary:    Qubes integration for Nautilus
@@ -424,7 +426,9 @@ make -C misc "DESTDIR=$RPM_BUILD_ROOT" UDEVRULESDIR=%_udevrulesdir SYSLIBDIR=/us
 make -C network DESTDIR=$RPM_BUILD_ROOT install
 make -C passwordless-root DESTDIR=$RPM_BUILD_ROOT install install-rh
 make -C qubes-rpc DESTDIR=$RPM_BUILD_ROOT install
+%if 0%{?rhel} != 7
 make -C qubes-rpc/caja DESTDIR=$RPM_BUILD_ROOT install
+%endif
 make -C qubes-rpc/kde DESTDIR=$RPM_BUILD_ROOT install
 make -C qubes-rpc/nautilus DESTDIR=$RPM_BUILD_ROOT install
 make -C qubes-rpc/thunar DESTDIR=$RPM_BUILD_ROOT install
@@ -976,11 +980,13 @@ rm -f %{name}-%{version}
 %{python3_sitelib}/dnf-plugins/*
 %endif
 
+%if 0%{?rhel} != 7
 %files caja
 /usr/share/caja-python/extensions/qvm_copy_caja.py*
 /usr/share/caja-python/extensions/qvm_move_caja.py*
 /usr/share/caja-python/extensions/qvm_dvm_caja.py*
 /usr/lib/qubes/qvm_caja_bookmark.sh
+%endif
 
 %files nautilus
 /usr/share/nautilus-python/extensions/qvm_copy_nautilus.py*


### PR DESCRIPTION
Do not fail package installation in chroot (like during template build
or in CI) - there, systemctl can't really communicate with real systemd,
but that isn't an error.