### PR TITLE
Label Xen hotplug scripts correctly

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -371,6 +371,9 @@ if [ "$1" -eq 0 ]; then
         %{_datadir}/selinux/packages/qubes-misc.pp
 fi || :
 
+%pre selinux
+%selinux_relabel_pre
+
 %posttrans selinux
 %selinux_relabel_post
 %systemd_post qubes-relabel-root.service qubes-relabel-rw.service

--- a/selinux/qubes-misc.fc
+++ b/selinux/qubes-misc.fc
@@ -8,7 +8,7 @@ define(`slash_run',`dnl
 /usr/lib/qubes(/.*)?                    gen_context(system_u:object_r:bin_t,s0)
 /usr/lib/qubes/init(/.*)?            -d gen_context(system_u:object_r:etc_t,s0)
 /usr/lib/qubes/init(/.*)?            -- gen_context(system_u:object_r:initrc_exec_t,s0)
-/etc/xen/scripts/[!/]+               -- gen_context(system_u:object_r:initrc_exec_t,s0)
+/etc/xen/scripts/[^/]+               -- gen_context(system_u:object_r:initrc_exec_t,s0)
 /usr/lib/qubes/network-manager-prepare-conf-dir -- gen_context(system_u:object_r:bin_t,s0)
 slash_run(`qubes(/.*)?',`qubes_var_run')
 slash_run(`qubes-service',`initrc_var_run',`-d')


### PR DESCRIPTION
They should be `initrc_exec_t`, but due to an incorrect regular expression this did not happen.  `[!/]+` matches one or more `!` or `/` characters, whereas `[^/]+` matches one or more characters that are not `/`.