### PR TITLE
Allow forwarding traffic that did not originate from netback

### DIFF
--- a/network/qubes-ipv4.nft
+++ b/network/qubes-ipv4.nft
@@ -24,7 +24,6 @@ table ip qubes {
       jump custom-forward
       ct state invalid counter drop
       ct state related,established accept
-      iifgroup != 2 counter drop
       oifgroup 2 counter drop
    }
 

--- a/network/qubes-ipv6.nft
+++ b/network/qubes-ipv6.nft
@@ -29,7 +29,6 @@ table ip6 qubes {
       type filter hook forward priority filter; policy accept;
       ct state invalid counter drop
       ct state related,established accept
-      iifgroup != 2 counter drop
       oifgroup 2 counter drop
    }
 


### PR DESCRIPTION
This unbreaks container networking, wireless hotspots, and much more.

Reported-by: Frédéric Pierret <frederic.pierret@qubes-os.org>
Fixes: QubesOS/qubes-issues#8222