### PR TITLE
Fix rapid network uplink disconnect and reconnect

### DIFF
--- a/network/udev-qubes-network.rules
+++ b/network/udev-qubes-network.rules
@@ -1,5 +1,8 @@
-# old udev has ENV{ID_NET_DRIVER}
-SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", ENV{ID_NET_DRIVER}=="vif", ENV{SYSTEMD_WANTS}+="qubes-network-uplink@%k.service"
-SUBSYSTEMS=="net", KERNEL=="eth*", ACTION=="remove", ENV{ID_NET_DRIVER}=="vif", ENV{SYSTEMD_WANTS}+="qubes-network-uplink@%k.service"
 # new udev has DRIVERS
-SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", DRIVERS=="vif", ENV{SYSTEMD_WANTS}+="qubes-network-uplink@%k.service"
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", DRIVERS=="vif", RUN+="/usr/bin/systemctl restart --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="remove", DRIVERS=="vif", RUN+="/usr/bin/systemctl stop --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+# old udev has ENV{NET_ID_DRIVER}
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", ENV{NET_ID_DRIVER}=="vif", RUN+="/usr/bin/systemctl restart --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="remove", ENV{NET_ID_DRIVER}=="vif", RUN+="/usr/bin/systemctl stop --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+
+LABEL="QUBES-NET-END"

--- a/vm-systemd/qubes-network-uplink@.service
+++ b/vm-systemd/qubes-network-uplink@.service
@@ -1,8 +1,6 @@
 [Unit]
 Description=Qubes network uplink (%i) setup
 After=network-pre.target qubes-iptables.service
-After=sys-subsystem-net-devices-%i.device
-BindsTo=sys-subsystem-net-devices-%i.device
 Before=network.target
 Wants=network.target
 


### PR DESCRIPTION
SYSTEMD_WANTS= does not conflict with existing systemd jobs.  Therefore, if a stop job is in progress for qubes-network-uplink@eth0.service, a new start job will not be queued after it.  The result is that qubes-network-uplink@eth0.service stays stopped and the qube has no network access.

Additionally, systemd assumes that udev change events are harmless, but the rule is written such that a change event would clear SYSTEMD_WANTS. This is incorrect.

Per [a comment by Lennart Poettering][1] it appears that SYSTEMD_WANTS+= is intended for persistent daemons, not short-running scripts. Furthermore, `man 7 udev` states:

> Running an event process for a long period of time may block all
> further events for this or a dependent device.

which implies that events for _other_ devices will continue to be processed.  Therefore, use RUN+="systemctl --job-mode=replace" to ensure that all conflicting stop jobs get cancelled and wait for the start job to complete.  This ensures that future events will not be processed until the start job has completed.

Marek Marczykwoski-Górecki found that this caused problems in CI. Frédéric Pierret found that this also happens outside of CI, making this problem much more serious.

[1]: https://github.com/systemd/systemd/issues/27549#issuecomment-1546990427

Fixes: QubesOS/qubes-issues#8237
Reported-by: Marek Marczykwoski-Górecki <marmarek@invisiblethingslab.com>
Reported-by: Frédéric Pierret <frederic.pierret@qubes-os.org>