### PR TITLE
Use network-pre.target to order firewall before network uplink

### DIFF
--- a/vm-systemd/qubes-antispoof.service
+++ b/vm-systemd/qubes-antispoof.service
@@ -4,7 +4,8 @@ Description=Qubes anti-spoofing firewall rules
 [Service]
 Type=oneshot
 RemainAfterExit=yes
+Before=network-pre.target
 ExecStart=/usr/sbin/nft -f /etc/qubes/qubes-antispoof.nft
 
 [Install]
-WantedBy=basic.target
+RequiredBy=network-pre.target

--- a/vm-systemd/qubes-iptables.service
+++ b/vm-systemd/qubes-iptables.service
@@ -2,6 +2,7 @@
 Description=Qubes base firewall settings
 Requires=qubes-antispoof.service
 After=qubes-antispoof.service
+Before=network-pre.target
 
 [Service]
 Type=oneshot
@@ -9,4 +10,4 @@ RemainAfterExit=yes
 ExecStart=/usr/lib/qubes/init/qubes-iptables start
 
 [Install]
-WantedBy=basic.target
+RequiredBy=network-pre.target

--- a/vm-systemd/qubes-network-uplink@.service
+++ b/vm-systemd/qubes-network-uplink@.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Qubes network uplink (%i) setup
-After=network-pre.target qubes-iptables.service
+After=network-pre.target
+Requires=network-pre.target
 Before=network.target
 Wants=network.target
 


### PR DESCRIPTION
network-pre.target is intended to be ordered after any service that sets up a firewall and before any service that enables networking. Therefore, have network-pre.target require qubes-antispoof.service (unconditionally) and qubes-iptables.service (only if qubes-iptables.service is enabled).  qubes-network-uplink@.service now has Requires= and After= dependencies on network-pre.target, so it is ordered after both Qubes and third-party firewall rules.