### PR TITLE
Ensure correct labeling of ~/QubesIncoming

### DIFF
--- a/selinux/qubes-qfile-unpacker.fc
+++ b/selinux/qubes-qfile-unpacker.fc
@@ -1,3 +1,3 @@
 `/usr/lib/\.modules_work(/.*)? <<none>>'
-`/(root|home/[^/]+)/QubesIncoming(/.*)?' gen_context(system_u:object_r:qubes_unpacked_file_t,s0)
+HOME_DIR/QubesIncoming(/.*)? gen_context(system_u:object_r:qubes_unpacked_file_t,s0)
 `/usr/lib/qubes/qfile-unpacker' -- gen_context(system_u:object_r:qubes_qfile_unpacker_exec_t,s0)

--- a/selinux/qubes-qfile-unpacker.te
+++ b/selinux/qubes-qfile-unpacker.te
@@ -37,7 +37,7 @@ allow qubes_qfile_unpacker_t { sysadm_usertype staff_usertype unconfined_usertyp
 # to create ~/QubesIncoming
 allow qubes_qfile_unpacker_t { user_home_dir_t admin_home_t }:dir { add_name search write };
 allow qubes_qfile_unpacker_t qubes_unpacked_file_t:dir { add_name search write create getattr mounton open read setattr };
-type_transition qubes_qfile_unpacker_t { user_home_dir_t admin_home_t }:dir qubes_unpacked_file_t "QubesIncoming";
+type_transition { sysadm_usertype staff_usertype unconfined_usertype initrc_domain qubes_qfile_unpacker_t } { user_home_dir_t admin_home_t }:dir qubes_unpacked_file_t "QubesIncoming";
 allow qubes_qfile_unpacker_t qubes_unpacked_file_t:file { append create getattr link open setattr write };
 dontaudit qubes_qfile_unpacker_t { user_home_t admin_home_t }:file read;
 allow qubes_qfile_unpacker_t qubes_unpacked_file_t:lnk_file { create getattr setattr };


### PR DESCRIPTION
This requires using the special HOME_DIR keyword in the .fc file and ensuring that the appropriate labels are included in the relevant type_transition rule in the .te file.