### PR TITLE
(Re-)enable override-redirect windows in xfce4-notifyd

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -60,6 +60,7 @@ etc/sudoers.d/umask
 etc/sysctl.d/20_tcp_timestamps.conf
 etc/sysctl.d/80-qubes.conf
 etc/systemd/system/xendriverdomain.service
+etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
 lib/modules-load.d/qubes-core.conf
 lib/systemd/system-preset/75-qubes-vm.preset
 lib/systemd/system/boot.automount.d/30_qubes.conf

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -43,6 +43,8 @@ install:
 	install -m 0755 -t $(DESTDIR)$(BINDIR) qvm-features-request
 	install -m 0755 -d $(DESTDIR)$(QUBESLIBDIR)
 	install -m 0755 -t $(DESTDIR)$(QUBESLIBDIR) qvm-service-wrapper
+	install -m 0755 -d $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml
+	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml xfce4-notifyd.xml
 
 marker-vm: marker-vm.in
 	printf "$(VERSION)" | cut -f 1,2 -d . | cat $< - > marker-vm

--- a/misc/xfce4-notifyd.xml
+++ b/misc/xfce4-notifyd.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="xfce4-notifyd" version="1.0">
+  <property name="compat" type="empty">
+    <property name="use-override-redirect-windows" type="bool" value="true"/>
+  </property>
+</channel>
+

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -888,6 +888,7 @@ rm -f %{name}-%{version}
 %endif
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
 %config(noreplace) /etc/dconf/db/local.d/dpi
+%config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
 %_udevrulesdir/50-qubes-mem-hotplug.rules
 %_unitdir/user@.service.d/90-session-stop-timeout.conf
 /usr/sbin/qubes-serial-login


### PR DESCRIPTION
Upstream decided to not use override-redirect windows for notifications
and use _MOTIF_WM_HINTS to mark those windows as borderless. The reason
was to not show the notifications over the screenlocker. In Qubes, we
have no intention of passing all possible window properties to the real
X server, but also the screenlocker issue doesn't apply as the
gui-daemon takes care to not show those above.

Thanks @rustybird for finding the solution.
Fixes QubesOS/qubes-issues#8181