### PR TITLE
Set correct SELinux contexts on /rw

### DIFF
--- a/init/functions
+++ b/init/functions
@@ -178,19 +178,29 @@ initialize_home() {
     home_root="$1"
     mode="$2"
 
-    if [ -z "$home_root" ] ; then
+    case $home_root in
+    (/*)
+        ;;
+    ('')
         echo "initialize_home() needs a target home root directory, such as /rw/home, as first parameter" >&2
         return 64
-    fi
+        ;;
+    (*)
+        echo 'initialize_home target root home directory must be an absolute path' >&2
+        return 64
+        ;;
+    esac
 
     if [ "$mode" != "unconditionally" ] && [ "$mode" != "ifneeded" ] ; then
         echo "initialize_home() second parameter must be 'unconditionally' or 'ifneeded'" >&2
         return 64
     fi
 
+    if test -d /sys/fs/selinux; then enable_selinux="Z"; else enable_selinux=''; fi
+
     if ! [ -d "$home_root" ] ; then
         echo "initialize_home: populating $home_root" >&2
-        mkdir -p "$home_root"
+        mkdir "-${enable_selinux}m0755" -- "$home_root" || return 73
     fi
 
     # Chown home if users' UIDs have changed - can be the case on template switch.
@@ -202,7 +212,6 @@ initialize_home() {
         homedirwithouthome=${homedir#/home/}
         if ! test -d "$home_root/$homedirwithouthome" || [ "$mode" = "unconditionally" ] ; then
             echo "initialize_home: populating $mode $home_root/$homedirwithouthome from /etc/skel" >&2
-            if test -d /sys/fs/selinux; then enable_selinux="Z"; else enable_selinux=''; fi
             if [ "$mode" = unconditionally ]; then
                 mkdir "-p${enable_selinux}" -- "$home_root/$homedirwithouthome" || return 73
             else

--- a/init/functions
+++ b/init/functions
@@ -202,8 +202,15 @@ initialize_home() {
         homedirwithouthome=${homedir#/home/}
         if ! test -d "$home_root/$homedirwithouthome" || [ "$mode" = "unconditionally" ] ; then
             echo "initialize_home: populating $mode $home_root/$homedirwithouthome from /etc/skel" >&2
-            mkdir -p "$home_root/$homedirwithouthome"
             if test -d /sys/fs/selinux; then enable_selinux="Z"; else enable_selinux=''; fi
+            if [ "$mode" = unconditionally ]; then
+                mkdir "-p${enable_selinux}" -- "$home_root/$homedirwithouthome" || return 73
+            else
+                case $homedirwithouthome in
+                (*/*) mkdir "-p${enable_selinux}" -- "$home_root/${homedirwithouthome%/*}";;
+                esac
+                mkdir "${enable_selinux+-Z}" -- "$home_root/$homedirwithouthome" || return 73
+            fi
             cp "-af$enable_selinux" -T /etc/skel "$home_root/$homedirwithouthome"
             echo "initialize_home: adjusting permissions $mode on $home_root/$homedirwithouthome" >&2
             chown -R "$uid" "$home_root/$homedirwithouthome" &

--- a/network/network-manager-prepare-conf-dir
+++ b/network/network-manager-prepare-conf-dir
@@ -4,10 +4,11 @@
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
 
+if test -d /sys/fs/selinux; then enable_selinux=Z; else enable_selinux=''; fi
 NM_CONFIG_DIR=/etc/NetworkManager/system-connections
 if [ -d $NM_CONFIG_DIR ] && [ ! -h $NM_CONFIG_DIR ]; then
-    mkdir -p /rw/config/NM-system-connections
-    mv $NM_CONFIG_DIR/* /rw/config/NM-system-connections/ 2> /dev/null || true
+    mkdir "-p$enable_selinux" /rw/config/NM-system-connections
+    mv ${enable_selinux:+-Z} $NM_CONFIG_DIR/* /rw/config/NM-system-connections/ 2> /dev/null || true
     rmdir $NM_CONFIG_DIR
     ln -s /rw/config/NM-system-connections $NM_CONFIG_DIR
 fi

--- a/network/network-manager-prepare-conf-dir
+++ b/network/network-manager-prepare-conf-dir
@@ -6,11 +6,11 @@
 
 if test -d /sys/fs/selinux; then enable_selinux=Z; else enable_selinux=''; fi
 NM_CONFIG_DIR=/etc/NetworkManager/system-connections
-if [ -d $NM_CONFIG_DIR ] && [ ! -h $NM_CONFIG_DIR ]; then
+if [ -d "$NM_CONFIG_DIR" ] && [ ! -h "$NM_CONFIG_DIR" ]; then
     mkdir "-p$enable_selinux" /rw/config/NM-system-connections
-    mv ${enable_selinux:+-Z} $NM_CONFIG_DIR/* /rw/config/NM-system-connections/ 2> /dev/null || true
-    rmdir $NM_CONFIG_DIR
-    ln -s /rw/config/NM-system-connections $NM_CONFIG_DIR
+    mv ${enable_selinux:+-Z} "$NM_CONFIG_DIR"/* /rw/config/NM-system-connections/ 2> /dev/null || true
+    rmdir "$NM_CONFIG_DIR"
+    ln -s /rw/config/NM-system-connections "$NM_CONFIG_DIR"
 fi
 
 # Do not manage xen-provided network devices
@@ -18,7 +18,7 @@ unmanaged_devices=mac:fe:ff:ff:ff:ff:ff
 #for mac in `xenstore-ls device/vif | grep mac | cut -d= -f2 | tr -d '" '`; do
 #    unmanaged_devices="$unmanaged_devices;mac:$mac"
 #done
-sed -r -i -e "s/^#?unmanaged-devices=.*/unmanaged-devices=$unmanaged_devices/" /etc/NetworkManager/NetworkManager.conf
-sed -r -i -e "s/^#?plugins=.*/plugins=keyfile/" /etc/NetworkManager/NetworkManager.conf
+sed -E -i -e "s/^#?unmanaged-devices=.*/unmanaged-devices=$unmanaged_devices/
+s/^#?plugins=.*/plugins=keyfile/" /etc/NetworkManager/NetworkManager.conf
 
 exit 0


### PR DESCRIPTION
This is needed for disposable sys-net to work properly.  Without it /rw is not labeled correctly, causing SELinux to (correctly) block NetworkManager's writes to /rw/config/NM-system-connections.

Fixes: QubesOS/qubes-issues#8242