### PR TITLE
Hide ibus icon by default

### DIFF
--- a/debian/qubes-core-agent.gsettings-override
+++ b/debian/qubes-core-agent.gsettings-override
@@ -1,2 +1,5 @@
 [org.mate.NotificationDaemon]
 theme='slider'
+
+[org.freedesktop.ibus.panel]
+show-icon-on-systray=false


### PR DESCRIPTION
Having an ibus tray icon from every (Debian bookworm) qube pollutes the
tray a lot. Disable it.

Fixes QubesOS/qubes-issues#8286