### PR TITLE
Drop requirement on iptables

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -147,7 +147,6 @@ package_qubes-vm-networking() {
         python
         iproute2
         networkmanager
-        iptables
         tinyproxy
         nftables
         conntrack-tools

--- a/debian/control
+++ b/debian/control
@@ -136,15 +136,13 @@ Architecture: any
 Depends:
     qubes-core-agent (= ${binary:Version}),
     tinyproxy,
-    iptables,
+    nftables,
     conntrack,
     socat,
     tinyproxy,
     iproute2,
     ${python3:Depends},
     ${misc:Depends}
-Suggests:
-    nftables,
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: Networking support for Qubes VM

--- a/network/qubes-iptables
+++ b/network/qubes-iptables
@@ -18,7 +18,7 @@
 # Description: Loads Qubes base iptables firewall
 ### END INIT INFO
 
-IPTABLES=iptables
+IPTABLES=nft
 IPTABLES_DATA_DIR=/etc/qubes
 
 if [ ! -x "/sbin/$IPTABLES" ]; then
@@ -60,7 +60,7 @@ case "$1" in
 	RETVAL=$?
 	;;
     *)
-	echo $"Usage: ${IPTABLES} start"
+	echo $"Usage: iptables start"
 	RETVAL=2
 	;;
 esac

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -266,7 +266,6 @@ Scripts required to handle dom0 updates.
 %package networking
 BuildArch:  noarch
 Summary:    Networking support for Qubes VM
-Requires:   iptables
 Requires:   conntrack-tools
 Requires:   iproute
 Requires:   nftables


### PR DESCRIPTION
iptables is not used any more.

Fixes: QubesOS/qubes-issues#5301
Fixes: QubesOS/qubes-issues#8346