### PR TITLE
Avoid stopping qubes-network-uplink@eth0.service

### DIFF
--- a/network/udev-qubes-network.rules
+++ b/network/udev-qubes-network.rules
@@ -1,8 +1,8 @@
 # new udev has DRIVERS
-SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", DRIVERS=="vif", RUN+="/usr/bin/systemctl restart --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", DRIVERS=="vif", RUN+="/usr/bin/systemctl start --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
 SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="remove", DRIVERS=="vif", RUN+="/usr/bin/systemctl stop --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
 # old udev has ENV{NET_ID_DRIVER}
-SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", ENV{NET_ID_DRIVER}=="vif", RUN+="/usr/bin/systemctl restart --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
+SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="add", ENV{NET_ID_DRIVER}=="vif", RUN+="/usr/bin/systemctl start --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
 SUBSYSTEMS=="xen", KERNEL=="eth*", ACTION=="remove", ENV{NET_ID_DRIVER}=="vif", RUN+="/usr/bin/systemctl stop --job-mode=replace qubes-network-uplink@%k.service", GOTO="QUBES-NET-END"
 
 LABEL="QUBES-NET-END"


### PR DESCRIPTION
This is already started by qubes-network-uplink.service, so stopping it is a bad idea.  Since setup-ip is not idempotent, the result is a down network interface.

Fixes: QubesOS/qubes-issues#8362
Fixes: QubesOS/qubes-issues#8305