### PR TITLE
Set initial ibus config version to avoid upgrade notification

### DIFF
--- a/debian/qubes-core-agent.gsettings-override
+++ b/debian/qubes-core-agent.gsettings-override
@@ -3,3 +3,4 @@ theme='slider'
 
 [org.freedesktop.ibus.panel]
 show-icon-on-systray=false
+version='1.5.27'


### PR DESCRIPTION
Ibus shows a one time notification on upgrade from before 1.5.26 about
Plasma Wayland incompatibility. It's shown on initial start (when there
is no previous config) too. The problem is, on Qubes, it isn't really
one time, it's one per qube, including every DispVM start.
Pretend new enough version was started before, to avoid notification
storm.

QubesOS/qubes-issues#8286