### PR TITLE
dom0-update: fix rpmdb migration logic

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -74,9 +74,11 @@ mkdir -p $DOM0_UPDATES_DIR/etc
 
 # remove converted sqlite db if legacy db is newer, to force conversion again
 # legacy db could be only in the /var/lib/rpm location, but sqlite could be in any
-if [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite" ]; then
+if [ -e "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite" ] && \
+       [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite" ]; then
     rm -f -- "$DOM0_UPDATES_DIR/var/lib/rpm/rpmdb.sqlite"*
-elif [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm/rpmdb.sqlite" ]; then
+elif [ -e "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm/rpmdb.sqlite" ] && \
+         [ "$DOM0_UPDATES_DIR/var/lib/rpm/Packages" -nt "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm/rpmdb.sqlite" ]; then
     # remove the whole directory, to make the logic below happy
     rm -rf -- "$DOM0_UPDATES_DIR/usr/lib/sysimage/rpm"
 fi


### PR DESCRIPTION
Fix checking if dom0's (bdb format) rpmdb is newer than converted one
(sqlite format in either /var/lib/rpm or /usr/lib/sysimage/rpm
directory).
The issue was that '-nt' consider existing file always newer than
non-existing one. This means, the logic selected to remove (supposedly)
old /var/lib/rpm/rpmdb.sqlite, instead of
/usr/lib/sysimage/rpm/rpmdb.sqlite when the former doesn't exist.

This fix is necessary for R4.1->R4.2 upgrade and needs to be backported
to release4.1 branch.

QubesOS/qubes-issues#7832