### PR TITLE
Make services conditional

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,13 @@ endif
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service
 
-USER_DROPINS :=
+USER_DROPINS := \
+	tracker-xdg-portal-3.service \
+	tracker-writeback-3.service \
+	tracker-miner-rss-3.service \
+	tracker-miner-fs-control-3.service \
+	tracker-miner-fs-3.service \
+	tracker-extract-3.service
 
 # Ubuntu Dropins
 ifeq ($(release),Ubuntu)

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,11 @@ USER_DROPINS := \
 	tracker-miner-rss-3.service \
 	tracker-miner-fs-control-3.service \
 	tracker-miner-fs-3.service \
-	tracker-extract-3.service
+	tracker-extract-3.service \
+	evolution-addressbook-factory.service \
+	evolution-calendar-factory.service \
+	evolution-source-registry.service \
+	evolution-user-prompter.service
 
 # Ubuntu Dropins
 ifeq ($(release),Ubuntu)

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -109,6 +109,10 @@ usr/lib/systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-miner-rss-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-writeback-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-xdg-portal-3.service.d/30_qubes.conf
+usr/lib/systemd/user/evolution-addressbook-factory.service.d/30_qubes.conf
+usr/lib/systemd/user/evolution-calendar-factory.service.d/30_qubes.conf
+usr/lib/systemd/user/evolution-source-registry.service.d/30_qubes.conf
+usr/lib/systemd/user/evolution-user-prompter.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules
 usr/bin/qubes-desktop-run
 usr/bin/qubes-open

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -103,6 +103,12 @@ lib/systemd/system/tor@default.service.d/30_qubes.conf
 lib/systemd/system/sysinit.target.requires
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-extract-3.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-miner-fs-3.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-miner-rss-3.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-writeback-3.service.d/30_qubes.conf
+usr/lib/systemd/user/tracker-xdg-portal-3.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules
 usr/bin/qubes-desktop-run
 usr/bin/qubes-open

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1184,6 +1184,10 @@ The Qubes core startup configuration for SystemD init.
 %_userunitdir/tracker-miner-rss-3.service.d/30_qubes.conf
 %_userunitdir/tracker-writeback-3.service.d/30_qubes.conf
 %_userunitdir/tracker-xdg-portal-3.service.d/30_qubes.conf
+%_userunitdir/evolution-addressbook-factory.service.d/30_qubes.conf
+%_userunitdir/evolution-calendar-factory.service.d/30_qubes.conf
+%_userunitdir/evolution-source-registry.service.d/30_qubes.conf
+%_userunitdir/evolution-user-prompter.service.d/30_qubes.conf
 
 %post systemd
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1178,6 +1178,12 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/tor@default.service.d/30_qubes.conf
 %_unitdir/tmp.mount.d/30_qubes.conf
 %_unitdir/sysinit.target.requires/systemd-random-seed.service
+%_userunitdir/tracker-extract-3.service.d/30_qubes.conf
+%_userunitdir/tracker-miner-fs-3.service.d/30_qubes.conf
+%_userunitdir/tracker-miner-fs-control-3.service.d/30_qubes.conf
+%_userunitdir/tracker-miner-rss-3.service.d/30_qubes.conf
+%_userunitdir/tracker-writeback-3.service.d/30_qubes.conf
+%_userunitdir/tracker-xdg-portal-3.service.d/30_qubes.conf
 
 %post systemd
 

--- a/vm-systemd/user/evolution-addressbook-factory.service.d/30_qubes.conf
+++ b/vm-systemd/user/evolution-addressbook-factory.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/evolution-data-server

--- a/vm-systemd/user/evolution-calendar-factory.service.d/30_qubes.conf
+++ b/vm-systemd/user/evolution-calendar-factory.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/evolution-data-server

--- a/vm-systemd/user/evolution-source-registry.service.d/30_qubes.conf
+++ b/vm-systemd/user/evolution-source-registry.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/evolution-data-server

--- a/vm-systemd/user/evolution-user-prompter.service.d/30_qubes.conf
+++ b/vm-systemd/user/evolution-user-prompter.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/evolution-data-server

--- a/vm-systemd/user/tracker-extract-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-extract-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker

--- a/vm-systemd/user/tracker-miner-fs-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-miner-fs-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker

--- a/vm-systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker

--- a/vm-systemd/user/tracker-miner-rss-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-miner-rss-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker

--- a/vm-systemd/user/tracker-writeback-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-writeback-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker

--- a/vm-systemd/user/tracker-xdg-portal-3.service.d/30_qubes.conf
+++ b/vm-systemd/user/tracker-xdg-portal-3.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=/run/qubes-service/tracker


### PR DESCRIPTION
This allows services that are currently started in every non-minimal Fedora qube to be controlled via `qvm-service`.