### PR TITLE
Set default text/plain editor to something not LibreOffice

### DIFF
--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -102,6 +102,8 @@ update_qubesconfig() {
 
     dconf update &> /dev/null || :
 
+    /usr/lib/qubes/set-default-text-editor
+
     # Location of files which contains list of protected files
     mkdir -p /etc/qubes/protected-files.d
     # shellcheck source=init/functions

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -154,6 +154,7 @@ usr/lib/qubes/upgrades-installed-check
 usr/lib/qubes/upgrades-status-notify
 usr/lib/qubes/vm-file-editor
 usr/lib/qubes/xdg-icon
+usr/lib/qubes/set-default-text-editor
 usr/lib/qubes/tinyproxy-wrapper
 usr/share/glib-2.0/schemas/*
 usr/share/kde4/services/*.desktop
@@ -163,6 +164,7 @@ usr/share/keyrings/qubes-ubuntu-archive-keyring.gpg
 usr/share/keyrings/qubes-ubuntu-archive-keyring-4.2.gpg
 usr/share/kservices5/ServiceMenus/*.desktop
 usr/share/applications/*.desktop
+usr/share/applications/defaults.list
 usr/share/man/man1/qvm-*
 usr/share/qubes/mime-override/globs
 usr/share/qubes/qubes-master-key.asc

--- a/debian/qubes-core-agent.postinst
+++ b/debian/qubes-core-agent.postinst
@@ -202,6 +202,8 @@ case "${1}" in
             dconf update
         fi
 
+        /usr/lib/qubes/set-default-text-editor
+
         # tell dom0 about installed updates (applications, features etc)
         /etc/qubes-rpc/qubes.PostInstall || true
         ;;

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,7 @@ export PYTHON_PREFIX_ARG=--install-layout=deb
 
 include /usr/share/dpkg/default.mk
 export DESTDIR=$(shell pwd)/debian/tmp
+DISTRIBUTION := $(shell lsb_release -is)
 
 %:
 	dh $@ --with systemd,python3 --with=config-package
@@ -38,6 +39,9 @@ override_dh_systemd_start:
 	dh_systemd_start --no-restart-on-upgrade
 
 override_dh_install:
+	if [ "$(DISTRIBUTION)" = "Ubuntu" ]; then \
+		sed -i '/defaults.list/d' debian/qubes-core-agent.install; \
+	fi
 	dh_install --fail-missing
 
 override_dh_gencontrol:

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -7,6 +7,8 @@ UDEVRULESDIR := $(SYSLIBDIR)/udev/rules.d
 QUBESDATADIR := $(DATADIR)/qubes
 QUBESMIMEDIR := $(QUBESDATADIR)/xdg-override
 
+release := $(shell lsb_release -is)
+
 .PHONY: all clean install
 
 all: marker-vm
@@ -39,10 +41,14 @@ install:
 	done < data-dirs
 	$(RM) mime/icons
 	umask 022 && cp -r applications mime '$(DESTDIR)$(QUBESMIMEDIR)'
+	if [ "$(release)" != "Ubuntu" ]; then \
+		ln -s mimeapps.list $(DESTDIR)/usr/share/applications/defaults.list; \
+	fi
 	install -m 0755 -d $(DESTDIR)$(BINDIR)
 	install -m 0755 -t $(DESTDIR)$(BINDIR) qvm-features-request
 	install -m 0755 -d $(DESTDIR)$(QUBESLIBDIR)
 	install -m 0755 -t $(DESTDIR)$(QUBESLIBDIR) qvm-service-wrapper
+	install -m 0755 -t $(DESTDIR)$(QUBESLIBDIR) set-default-text-editor
 	install -m 0755 -d $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml
 	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml xfce4-notifyd.xml
 

--- a/misc/set-default-text-editor
+++ b/misc/set-default-text-editor
@@ -1,0 +1,56 @@
+#!/bin/sh
+
+text_plain_app=$(xdg-mime query default text/plain)
+
+if [ -n "$text_plain_app" ] && 
+   [ -e "/usr/share/applications/$text_plain_app" ] &&
+   [ "$text_plain_app" != "libreoffice-writer.desktop" ]; then
+    # not set to libreoffice, nothing to do
+    exit 0
+fi
+
+text_plain_apps=$(
+    grep -rl '^MimeType=.*text/plain;' "/usr/share/applications" |
+    LC_ALL=C sort |
+    while read -r app; do
+        app_name=$(basename "$app")
+        if grep -q '^Terminal=[tT]' "$app"; then
+            continue
+        elif [ "$app_name" = "libreoffice-writer.desktop" ]; then
+            continue
+        fi
+        printf "%s" "$app_name;"
+    done
+)
+
+if [ -z "$text_plain_apps" ]; then
+    echo "No application handle text/plain, do not set default" >&2
+    exit 0
+fi
+
+mimeapps_file="/usr/share/applications/mimeapps.list"
+touch "$mimeapps_file"
+awk -v apps="$text_plain_apps" '
+/^\[/ {
+    if (indefault && !added) {
+        print "text/plain=" apps
+            added=1
+    }
+    indefault=0
+}
+/^\[Default Applications\]/ { indefault=1 }
+/^text\/plain=/ {
+    if (indefault) { print "text/plain=" apps; added=1 }
+    else { print }
+    next
+}
+/./ { print }
+END {
+    if (!added) {
+        if (!indefault) { print "[Default Applications]" }
+        print "text/plain=" apps
+    }
+}
+' < "$mimeapps_file" > "$mimeapps_file.new" && \
+    mv "$mimeapps_file.new" "$mimeapps_file"
+

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -522,6 +522,8 @@ dconf update &> /dev/null || :
 # And actually setup the proxy usage in package managers
 /usr/lib/qubes/update-proxy-configs
 
+/usr/lib/qubes/set-default-text-editor
+
 # Location of files which contains list of protected files
 mkdir -p /etc/qubes/protected-files.d
 . /usr/lib/qubes/init/functions
@@ -918,6 +920,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/upgrades-status-notify
 /usr/lib/qubes/qubes-sync-clock
 /usr/lib/qubes/resize-rootfs
+/usr/lib/qubes/set-default-text-editor
 /usr/lib/qubes/tinyproxy-wrapper
 /usr/lib/dracut/dracut.conf.d/30-qubes.conf
 %dir /usr/lib/qubes/init
@@ -938,6 +941,7 @@ rm -f %{name}-%{version}
 /usr/share/applications/qubes-run-terminal.desktop
 /usr/share/applications/qubes-open-file-manager.desktop
 /usr/share/applications/qvm-open-in-dvm.desktop
+/usr/share/applications/defaults.list
 /usr/share/qubes/serial.conf
 /usr/share/qubes/marker-vm
 /usr/share/glib-2.0/schemas/20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override


### PR DESCRIPTION
Debian does not define default application, so the choice is a bit
random (in practice - lexicographical). For text/plain, it hits
LibreOffice, which is very unfriendly for text/plain. Choose something
that is not libreoffice instead.
Fedora does define gedit as default editor, but xdg-open doesn't handle
mimeapps.list, it only looks for defaults.list file. Add a symlink to
fix this.

Fixes QubesOS/qubes-issues#8385