### PR TITLE
Do not disable tracker and evolution-data-server in AppVMs

### DIFF
--- a/vm-systemd/qubes-sysinit.sh
+++ b/vm-systemd/qubes-sysinit.sh
@@ -8,7 +8,7 @@ set -euf
 # List of services enabled by default (in case of absence of qubesdb entry)
 DEFAULT_ENABLED_NETVM="network-manager qubes-network qubes-update-check qubes-updates-proxy meminfo-writer qubes-firewall"
 DEFAULT_ENABLED_PROXYVM="qubes-network qubes-firewall qubes-update-check meminfo-writer"
-DEFAULT_ENABLED_APPVM="qubes-update-check meminfo-writer"
+DEFAULT_ENABLED_APPVM="qubes-update-check meminfo-writer tracker evolution-data-server"
 DEFAULT_ENABLED_TEMPLATEVM="$DEFAULT_ENABLED_APPVM updates-proxy-setup"
 DEFAULT_ENABLED="meminfo-writer"
 


### PR DESCRIPTION
Contrary to initial tests, disbling those do break some applications.
So, do not disable them by default in AppVMs.
But keep them disabled in system vms, as user applications are not
expected there.

QubesOS/qubes-issues#8372