### PR TITLE
Fix qubes.TemplateSearch with repo_gpgcheck=1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -125,6 +125,7 @@ Depends:
     dnf | yum-utils,
     curl,
     qubes-core-qrexec,
+    qubes-repo-templates,
 Replaces: qubes-core-agent (<< 4.1.28-1)
 Breaks: qubes-core-agent (<< 4.1.28-1)
 Description: Scripts required to handle dom0 updates.

--- a/qubes-rpc/qvm-template-repo-query
+++ b/qubes-rpc/qvm-template-repo-query
@@ -26,8 +26,7 @@ repodir=$(mktemp -d)
 trap 'rm -r "$repodir"' EXIT
 cat > "$repodir/template.repo"
 
-OPTS+=("--setopt=reposdir=${repodir}")
-OPTS+=("--quiet")
+OPTS+=(-y "--setopt=reposdir=${repodir}" --quiet)
 
 # use vendored 'downloadurl' dnf-plugin (fork of 'download' plugin), to print
 # all mirrors

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -259,6 +259,7 @@ Requires:   qubes-core-agent = %{version}
 Requires:   fakeroot
 Conflicts:  qubes-core-vm < 4.0.0
 Requires:   tar
+Requires:   qubes-repo-templates
 
 %description dom0-updates
 Scripts required to handle dom0 updates.


### PR DESCRIPTION
qubes-core-agent-dom0-updates was missing a dependency on qubes-repo-templates, so the OpenPGP keys needed with repo_gpgcheck=1 weren't available to DNF.  Also add -y to the DNF command line so that it imports these keys without a prompt.

Fixes: QubesOS/qubes-issues#7414