### PR TITLE
Fix tiny mistake in qubesdb path in `setup-ip`

### DIFF
--- a/network/setup-ip
+++ b/network/setup-ip
@@ -210,7 +210,7 @@ fi
 
 if [ "$ACTION" == "add" ]; then
     MAC="$(get_mac_from_iface "$INTERFACE")"
-    prefix="/net-config/$MAC"
+    prefix="/net-config/$MAC/"
     if [[ -n "$MAC" ]]; then
         # prefix begins with / so -- is not needed
         if /usr/bin/qubesdb-read "${prefix}custom" >/dev/null 2>&1; then


### PR DESCRIPTION
I found this tiny error when reading through the file. When trying to resolve the `/net-config/<mac address>` prefixed network settings from `qubesdb`, a missing slash garbles the paths.

That is, `"${prefix}ip"` would turn into something like `"/net-config/00:16:3e:5e:6c:00ip"` instead of the intended `"/net-config/00:16:3e:5e:6c:00/ip"`.