### PR TITLE
Disable multicast DNS and link-local multicast name resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,13 +141,19 @@ SYSTEMD_CORE_SERVICES := $(filter-out $(SYSTEMD_NETWORK_SERVICES) $(SYSTEMD_SELI
 
 .PHONY: install-systemd
 install-systemd: install-init
-	install -d $(DESTDIR)$(SYSLIBDIR)/systemd/system{,-preset} $(DESTDIR)$(LIBDIR)/qubes/init $(DESTDIR)$(SYSLIBDIR)/modules-load.d $(DESTDIR)/etc/systemd/system $(DESTDIR)$(SYSLIBDIR)/systemd/network
+	install -d $(DESTDIR)$(SYSLIBDIR)/systemd/system{,-preset} \
+		$(DESTDIR)$(LIBDIR)/qubes/init \
+		$(DESTDIR)$(SYSLIBDIR)/modules-load.d \
+		$(DESTDIR)/etc/systemd/system \
+		$(DESTDIR)$(SYSLIBDIR)/systemd/network \
+		$(DESTDIR)$(SYSLIBDIR)/systemd/resolved.conf.d/
 	install -m 0644 $(SYSTEMD_CORE_SERVICES) $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/qubes-*.timer $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/75-qubes-vm.preset $(DESTDIR)$(SYSLIBDIR)/systemd/system-preset/
 	install -m 0644 vm-systemd/qubes-core.conf $(DESTDIR)$(SYSLIBDIR)/modules-load.d/
 	install -m 0644 vm-systemd/xendriverdomain.service $(DESTDIR)/etc/systemd/system/
 	install -m 0644 vm-systemd/80-qubes-vif.link $(DESTDIR)$(SYSLIBDIR)/systemd/network/
+	install -m 0644 vm-systemd/30_resolved-no-mdns-or-llmnr.conf $(DESTDIR)$(SYSLIBDIR)/systemd/resolved.conf.d/
 
 .PHONY: install-sysvinit
 install-sysvinit: install-init

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -103,6 +103,7 @@ lib/systemd/system/tor@default.service.d/30_qubes.conf
 lib/systemd/system/sysinit.target.requires
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
+lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
 usr/lib/systemd/user/tracker-extract-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-miner-fs-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -949,6 +949,7 @@ rm -f %{name}-%{version}
 /usr/share/glib-2.0/schemas/20_org.mate.NotificationDaemon.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.gnome.desktop.wm.preferences.qubes.gschema.override
 %{_mandir}/man1/qvm-*.1*
+/usr/lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
 
 %dir %{python3_sitelib}/qubesagent-*-py*.egg-info
 %{python3_sitelib}/qubesagent-*-py*.egg-info/*

--- a/vm-systemd/30_resolved-no-mdns-or-llmnr.conf
+++ b/vm-systemd/30_resolved-no-mdns-or-llmnr.conf
@@ -1,0 +1,4 @@
+# Disable mDNS and LLMNR to reduce cross-VM attack surface.
+[Resolve]
+MulticastDNS=no
+LLMNR=no


### PR DESCRIPTION
These protocols increase the attack surface of a VM that is exposed to attackers that are network-adjacent to that VM, such as VMs that this VM provides network to or that provide network to the VM.  LLMNR is deprecated in favor of mDNS, which is provided by Avahi in Fedora. Qubes OS already disables Avahi by default, so disabling LLMNR and mDNS
in systemd-resolved is unlikely to break any existing workflows.

Fixes: QubesOS/qubes-issues#8444