### PR TITLE
Limit initramfs size to fix booting with limited memory size

### DIFF
--- a/boot/dracut-qubes.conf
+++ b/boot/dracut-qubes.conf
@@ -2,3 +2,11 @@
 # technically it is different system. Especially it has different devices
 # mounted (own /rw, own swap etc), so prevent hardcoding UUIDs here.
 hostonly="no"
+
+# Limit size of modules included, RAM during boot is at premium
+drivers="xen-blkfront dm-mod dm-thin-pool dm-persistent-data ext4 overlay"
+# Avoid pulling in a bunch of network drivers, and the whole network-manager.
+# There is no need for networking in VM's initramfs.
+# Remove also other modules not relevant for qubes VM, due to known filesystem
+# setup, and not interacting with VGA console during boot.
+omit_dracutmodules+=" ifcfg qemu-net i18n resume mdraid terminfo crypt lunmask nvdimm nss-softokn "


### PR DESCRIPTION
This change reduces intramfs size to about 17MB.

Fixes QubesOS/qubes-issues#8540