### PR TITLE
Provide a alternate qfile-unpacker that is not SELinux-confined

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -115,6 +115,7 @@ usr/lib/systemd/user/evolution-calendar-factory.service.d/30_qubes.conf
 usr/lib/systemd/user/evolution-source-registry.service.d/30_qubes.conf
 usr/lib/systemd/user/evolution-user-prompter.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules
+usr/bin/qfile-unpacker
 usr/bin/qubes-desktop-run
 usr/bin/qubes-open
 usr/bin/qubes-session-autostart

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -50,6 +50,9 @@ install:
 	# Install qfile-unpacker as SUID, because it will fail to receive
 	# files from other vm.
 	install -t $(DESTDIR)$(QUBESLIBDIR) -m 4755 qfile-unpacker
+	# This version isn't confined by SELinux, so it supports other
+	# home directories.
+	install -t $(DESTDIR)$(BINDIR) -m 4755 qfile-unpacker
 	install -d $(DESTDIR)$(QUBESRPCCMDDIR)
 	install -t $(DESTDIR)$(QUBESRPCCMDDIR) \
 		qubes.Filecopy qubes.OpenInVM qubes.VMShell \

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -905,6 +905,7 @@ rm -f %{name}-%{version}
 /usr/lib/qubes/prepare-suspend
 /usr/lib/qubes/qfile-agent
 %attr(4755,root,root) /usr/lib/qubes/qfile-unpacker
+%attr(4755,root,root) %_bindir/qfile-unpacker
 /usr/lib/qubes/qopen-in-vm
 /usr/lib/qubes/qrun-in-vm
 /usr/lib/qubes/qubes-trigger-sync-appmenus.sh


### PR DESCRIPTION
Using this in the Qubes executor will allow using the Qubes executor with SELinux enforcing.