### PR TITLE
Fix partial IPv6 setup

### DIFF
--- a/network/setup-ip
+++ b/network/setup-ip
@@ -167,7 +167,7 @@ __EOF__
     # reload connection
     nmcli connection load "$nm_config" || :
     if [[ "$custom" = false ]]; then
-        /sbin/ip -- neighbour replace to "$gateway6" dev "$INTERFACE" \
+        /sbin/ip -- neighbour replace to "$gateway" dev "$INTERFACE" \
             lladdr "$netvm_mac" nud permanent
     fi
     if [ -n "$gateway6" ]; then

--- a/network/setup-ip
+++ b/network/setup-ip
@@ -34,7 +34,7 @@ configure_network () {
     fi
     if [ -n "$ip6" ]; then
         /sbin/ip -- address replace "$ip6/$netmask6" dev "$INTERFACE"
-        if [[ "$custom" = false ]]; then
+        if [ -n "$gateway6" ] && [[ "$custom" = false ]]; then
             /sbin/ip -- neighbour replace to "$gateway6" dev "$INTERFACE" \
                 lladdr "$netvm_mac" nud permanent
         fi
@@ -170,7 +170,7 @@ __EOF__
         /sbin/ip -- neighbour replace to "$gateway6" dev "$INTERFACE" \
             lladdr "$netvm_mac" nud permanent
     fi
-    if [ -n "$ip6" ]; then
+    if [ -n "$gateway6" ]; then
         if [[ "$custom" = false ]]; then
             /sbin/ip -- neighbour replace to "$gateway6" dev "$INTERFACE" \
                 lladdr "$netvm_mac" nud permanent
@@ -234,7 +234,7 @@ if [ "$ACTION" == "add" ]; then
         gateway=$(exec /usr/bin/qubesdb-read "${prefix}gateway")
         if ip6=$(exec /usr/bin/qubesdb-read "${prefix}ip6" 2>/dev/null); then
             netmask6=$(exec /usr/bin/qubesdb-read --default=128 "${prefix}netmask6")
-            gateway6=$(exec /usr/bin/qubesdb-read "${prefix}gateway6")
+            gateway6=$(exec /usr/bin/qubesdb-read --default="" "${prefix}gateway6")
         elif [[ "$?" != '2' ]]; then
             echo 'Could not check if IPv6 is enabled' >&2
             exit 1


### PR DESCRIPTION
Fix the case when qube provides IPv6 to others (for example via VPN), but
isn't itself connected to IPv6-providing qube. In this case, it will
have an IPv6 address but not IPv6 gateway. Do not fail in this case.