### PR TITLE
Add missing nft rule for ipv6 that is present for ipv4

### DIFF
--- a/network/qubes-ipv6.nft
+++ b/network/qubes-ipv6.nft
@@ -27,6 +27,7 @@ table ip6 qubes {
 
    chain forward {
       type filter hook forward priority filter; policy accept;
+      jump custom-forward
       ct state invalid counter drop
       ct state related,established accept
       oifgroup 2 counter drop


### PR DESCRIPTION
The rule to jump to custom-forward chain is present for ipv4:
https://github.com/QubesOS/qubes-core-agent-linux/blob/main/network/qubes-ipv4.nft#L24
But is missing for ipv6 so add it.