### PR TITLE
Add fallback for invalid bus names

### DIFF
--- a/qubesagent/xdg.py
+++ b/qubesagent/xdg.py
@@ -117,6 +117,12 @@ def launch(filename_or_entry, *files, **kwargs):
                     print(e)
                     # fallback to non-dbus version
                     pass
+                except ValueError as e:
+                    if str(e).startswith('Invalid bus name'):
+                        # fallback to non-dbus version
+                        pass
+                    else:
+                        raise e
                 else:
                     if wait:
                         loop.run()

--- a/qubesagent/xdg.py
+++ b/qubesagent/xdg.py
@@ -119,6 +119,7 @@ def launch(filename_or_entry, *files, **kwargs):
                     pass
                 except ValueError as e:
                     if str(e).startswith('Invalid bus name'):
+                        print(e)
                         # fallback to non-dbus version
                         pass
                     else:


### PR DESCRIPTION
When applications implement the DBusActivatable feature incorrectly, the app is currently not starting at all. This PR adds a fallback for these cases to start the app without dbus.

The reason for this patch is a [recent change](https://src.fedoraproject.org/rpms/firefox/c/85de885472621621af497b204a2f45f7122e8a23?branch=86e26c4189a0192cd1185839e03a9ffcb4fbde75) in the packaging of `firefox` for *fedora*. They attempted to implement `DBusActivatable` for `firefox`, but did not follow the complete specification. This causes `firefox` to be not launchable via the Qubes application launcher. The following error message is caused instead:

```python
Traceback (most recent call last):
  File "/etc/qubes-rpc/qubes.StartApp", line 39, in <module>
    main(sys.argv)
  File "/etc/qubes-rpc/qubes.StartApp", line 33, in main
    launch(os.path.join(raw_volume, f))
  File "/usr/lib/python3.11/site-packages/qubesagent/xdg.py", line 106, in launch
    proxy = bus.get_object(service_id, object_path)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/site-packages/dbus/bus.py", line 237, in get_object
    return self.ProxyObjectClass(self, bus_name, object_path,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.11/site-packages/dbus/proxies.py", line 241, in __init__
    _dbus_bindings.validate_bus_name(bus_name)
ValueError: Invalid bus name 'firefox': must contain '.'
```

This is a packaging issue of cause and not the fault of qubes. However, with the patch suggested in this PR qubes becomes immune if another package makes the same mistake.

Fixes https://github.com/QubesOS/qubes-issues/issues/8571