### PR TITLE
qfile-unpacker should not be an easy root hole

### DIFF
--- a/qubes-rpc/gui-fatal.c
+++ b/qubes-rpc/gui-fatal.c
@@ -35,9 +35,12 @@ static void produce_message(const char *type, const char *fmt, va_list args)
         case -1:
             exit(1); // what else
         case 0:
-            if (geteuid() == 0)
-                if (setuid(getuid()) != 0)
-                    perror("setuid failed, calling kdialog/zenity as root");
+            if (geteuid() == 0) {
+                if (setuid(getuid()) != 0) {
+                    perror("setuid failed, not calling kdialog/zenity");
+                    exit(1);
+                }
+            }
             fix_display();
 #ifdef USE_KDIALOG
             execlp("/usr/bin/kdialog", "kdialog", "--sorry", dialog_msg, NULL);

--- a/qubes-rpc/qfile-unpacker.c
+++ b/qubes-rpc/qfile-unpacker.c
@@ -20,6 +20,9 @@
 char *prepare_creds_return_dir(int uid)
 {
     const struct passwd *pwd;
+    uid_t myuid = getuid();
+    if (myuid != 0 && myuid != (uid_t)uid)
+        gui_fatal("Refusing to change to UID other than the caller's UID");
     pwd = getpwuid(uid);
     if (!pwd) {
         perror("getpwuid");


### PR DESCRIPTION
qfile-unpacker is setuid root so that it can call chroot().  Right now, it will happily change its filesystem UID to a value that is supplied on the command line, then chroot to a directory supplied on the command line, and finally create new files, directories, and symbolic links of the caller's choice.  This is enough to get root; a simple method is to drop a .conf file under /rw/bind-dirs (creating it if it does not exist) and wait for VM reboot.  The file will then be sourced as a shell script with root privileges.

Additionally, setuid() failing results in zenity or kdialog being run as root, which is not safe.  Neither zenity nor kdialog is safe when being run with privileges, and it is easy to make them execute arbitrary code by abusing GTK or Qt's environment variables.  Fortunately, setuid() failing is not common or easy to trigger.

While Qubes OS does not rely on user -> root to be a security boundary, it also does not try to sabotage that boundary, at least for users outside of the "qubes" group (which is considered to be privileged). Allowing arbitrary users (even "nobody", "guest", or "www") to get root is generally frowned upon.  Therefore, this problem should be fixed.

To fix this problem, refuse to change to a UID that is not the same as the real UID of the calling process, and do not invoke a GUI program if dropping privileges fails.