### PR TITLE
Detect and terminate infinite qrexec launch chains

### DIFF
--- a/qubes-rpc/qvm-open-in-vm
+++ b/qubes-rpc/qvm-open-in-vm
@@ -64,6 +64,24 @@ if [ -z "$target" ] || [ -z "$filename" ]; then
     usage
 fi
 
+prompt_text='Are you sure you want to create another disposable VM?'
+case $target in
+(@dispvm|@dispvm:*)
+    case ${QREXEC_SERVICE_FULL_NAME-} in
+    (qubes.OpenInVM+*|qubes.OpenURL+*)
+        if [ -f /usr/bin/zenity ]; then
+            zenity --question "--text=$prompt_text" || exit "$?"
+        elif [ -f /usr/bin/kdialog ]; then
+            kdialog "--yesno=$prompt_text" || exit "$?"
+        else
+            printf 'Cannot prompt user, exiting to avoid possible infinite VM creation loop.\n' >&2
+            exit 1
+        fi
+        ;;
+    esac
+    ;;
+esac
+
 expr "@$filename" : '@[A-Za-z][A-Za-z0-9+]*://'>/dev/null
 # shellcheck disable=SC2016
 case $? in


### PR DESCRIPTION
If a VM is set to use a disposable VM to handle URLs and is also its also default disposable VM template, attempting to open a URL in that VM will cause the newly created disposable VM to create yet another disposable VM and so on.  This is effectively a fork bomb, and will continue to create disposable VMs until a resource (usually memory) is exhausted.

To prevent this from happening, check if the VM was spawned via qubes.OpenURL or qubes.OpenInVM, and if the target of a call to qvm-open-in-vm is a disposable VM.  If both hold, prompt the user before creating the disposable VM.  If prompting is not possible, fail.

Tested with a modified Fedora template.

Fixes: QubesOS/qubes-issues#7406