### PR TITLE
Do not show "Displays" prompt in every VM when new display is connected

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -61,6 +61,7 @@ etc/sysctl.d/20_tcp_timestamps.conf
 etc/sysctl.d/80-qubes.conf
 etc/systemd/system/xendriverdomain.service
 etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
+etc/xdg/xfce4/xfconf/xfce-perchannel-xml/displays.xml
 lib/modules-load.d/qubes-core.conf
 lib/systemd/system-preset/75-qubes-vm.preset
 lib/systemd/system/boot.automount.d/30_qubes.conf

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -51,6 +51,7 @@ install:
 	install -m 0755 -t $(DESTDIR)$(QUBESLIBDIR) set-default-text-editor
 	install -m 0755 -d $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml
 	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml xfce4-notifyd.xml
+	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml displays.xml
 
 marker-vm: marker-vm.in
 	printf "$(VERSION)" | cut -f 1,2 -d . | cat $< - > marker-vm

--- a/misc/displays.xml
+++ b/misc/displays.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<channel name="displays" version="1.0">
+  <property name="Notify" type="int" value="0"/>
+</channel>
+

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -958,6 +958,7 @@ rm -f %{name}-%{version}
 %dir /etc/dconf/db/local.d
 %config(noreplace) /etc/dconf/db/local.d/dpi
 %config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
+%config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/displays.xml
 %_udevrulesdir/50-qubes-mem-hotplug.rules
 %_unitdir/user@.service.d/90-session-stop-timeout.conf
 /usr/sbin/qubes-serial-login


### PR DESCRIPTION
Default Xfce setting is to prompt what to do when new display is
connected. It makes sense in dom0 (or GUI domain), but not really in
every VM. Disable it by default. When setting up GUI domain, it will
need to be re-enabled manually (or possibly via salt).

Fixes QubesOS/qubes-issues#8756