### PR TITLE
Ensure XDG secrets portal is available

### DIFF
--- a/config-overrides/Makefile
+++ b/config-overrides/Makefile
@@ -19,3 +19,4 @@ install:
 		20_org.gnome.nautilus.qubes.gschema.override \
 		20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override \
 		20_org.mate.NotificationDaemon.qubes.gschema.override
+	install -D -m 0644 portals.conf $(DESTDIR)/usr/share/xdg-desktop-portal/portals.conf

--- a/config-overrides/portals.conf
+++ b/config-overrides/portals.conf
@@ -1,0 +1,13 @@
+# There are two reasons for this file:
+#
+# 1. xdg-desktop-portal does not provide org.freedesktop.impl.portal.Secret
+# 2. In Qubes OS, users can (and do) switch desktop environments, and the
+#    same secret service should be used even if the user switches from one
+#    to another.  Otherwise, users will lose access to existing secrets.
+#
+# This file is at /usr/share/xdg-desktop-portal/portals.conf, which is the
+# lowest-priority location for a portals.conf file.  It only overrides the
+# legacy UseIn= mechanism.  Therefore, users and desktop environments can
+# still override this choice.
+[preferred]
+org.freedesktop.impl.portal.Secret=gnome-keyring

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -190,3 +190,4 @@ usr/share/qubes/xdg-override/mime/*
 usr/share/qubes/xdg-override/mime/application/*.xml
 usr/share/qubes/xdg-override/mime/image/*.xml
 usr/share/qubes/xdg-override/mime/packages/*.xml
+usr/share/xdg-desktop-portal/portals.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1029,6 +1029,7 @@ rm -f %{name}-%{version}
 /usr/share/glib-2.0/schemas/20_org.gnome.nautilus.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.mate.NotificationDaemon.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.gnome.desktop.wm.preferences.qubes.gschema.override
+/usr/share/xdg-desktop-portal/portals.conf
 %{_mandir}/man1/qvm-*.1*
 # should be owned by systemd-network, but it isn't
 %dir /usr/lib/systemd/resolved.conf.d


### PR DESCRIPTION
Sandboxed applications use this to store secrets.  Without it, Element cannot access its secrets and resets itself, causing user data to be lost.  The version of xdg-desktop-portal in Fedora 38 and below would use any portal implementation it could find, but the version in Fedora 39 requires that portal implementations be specified in a config file. Provide that config file.

Fixes: QubesOS/qubes-issues#8839