### PR TITLE
Refuse to copy "." or ".."

### DIFF
--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -74,6 +74,13 @@ else
   VM="@default"
 fi
 
+for path; do
+    case $path in
+        (.|..) printf 'Refusing to copy "." or "..".
+Try copying from the parent directory.\n' >&2; exit 1;;
+    esac
+done
+
 if [ "$PROGRESS_TYPE" = console ] ; then
     find_paths=( )
     for path; do


### PR DESCRIPTION
In R4.2, these will be rejected on the receiving side with a confusing error.  Furthermore, the previous behavior (copying all files directly into `~/QubesIncoming/VMNAME`) wasn't intuitive either.  Just error out early with a more useful message.

Fixes: QubesOS/qubes-issues#8927