### PR TITLE
Ensure gnome-keyring always available

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -224,6 +224,9 @@ Source0: %{name}-%{version}.tar.gz
 %if %{with selinux}
 Requires: (%{name}-selinux if selinux-policy)
 %endif
+# Ensure that gnome-keyring is always available, so that changing
+# TemplateVMs doesn't break stuff that uses the secrets portal.
+Requires: (gnome-keyring if xdg-desktop-portal)
 
 %description
 The Qubes core files for installation inside a Qubes VM.


### PR DESCRIPTION
Sandboxed applications use a secrets portal implementation to store secrets.  Without it, Element cannot access its secrets and resets itself, causing user data to be lost.  However, there is no guarantee that a specific keyring implementation is currently used or even present, which would allow QubesOS/qubes-issues#8839 to recur.

To fix this, ensure that gnome-keyring is _always_ present by making it a hard dependency if xdg-desktop-portal is present.  This does _not_ enforce that it is always used, as there is no way to do that without choosing _all_ portal implementations.  However, it is the best way to ensure that the user does not lose data when they switch between TemplateVMs.