### PR TITLE
Use `O_NOFOLLOW` for the log file

### DIFF
--- a/qubes-rpc/vm-file-editor.c
+++ b/qubes-rpc/vm-file-editor.c
@@ -192,7 +192,7 @@ main(void)
             if (close(null_fd))
                 err(1, "close()");
 
-            log_fd = open("/tmp/mimeopen.log", O_CREAT | O_APPEND, 0666);
+            log_fd = open("/tmp/mimeopen.log", O_CREAT | O_APPEND | O_NOFOLLOW, 0666);
             if (log_fd == -1) {
                 perror("open /tmp/mimeopen.log");
                 _exit(1);


### PR DESCRIPTION
Prevents easy escalation to the "qubes" group via a symlink attack.