### PR TITLE
Force using 127.0.0.1 when connecting to updates proxy

### DIFF
--- a/qubes-rpc/qubes.UpdatesProxy
+++ b/qubes-rpc/qubes.UpdatesProxy
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec socat STDIO TCP:localhost:8082
+exec socat STDIO TCP4:127.0.0.1:8082


### PR DESCRIPTION
Recent change in socat made it prefer ::1 address for localhost. This
breaks updates proxy, because it allowed only 127.0.0.1. Force the IPv4
address. An alternative could be allowing IPv6 address in the proxy
instead, but since IPv6 can be disabled (Whonix does it), it would mean
having different paths depending on IP settings, which could be
confusing at times.

Fixes QubesOS/qubes-issues#9025