### PR TITLE
Enable Arch repositories

### DIFF
--- a/archlinux/PKGBUILD-qubes-repo-4.2.conf
+++ b/archlinux/PKGBUILD-qubes-repo-4.2.conf
@@ -1,3 +1,13 @@
-[qubes-r4.2]
-#Replace the server below with your own
-#Server = https://YOUR_OWN_SERVER
+[qubes-r4.2-current-testing]
+Server = https://archlinux.qubes-os.org/r4.2/current-testing/vm/archlinux/pkgs
+# Work around a bug in libalpm: if Server= is only listed once, libalpm
+# dereferences a NULL pointer when trying to download the database signature.
+Server = https://archlinux.qubes-os.org/r4.2/current-testing/vm/archlinux/pkgs
+SigLevel = Required TrustedOnly
+
+[qubes-r4.2-current]
+Server = https://archlinux.qubes-os.org/r4.2/current/vm/archlinux/pkgs
+# Work around a bug in libalpm: if Server= is only listed once, libalpm
+# dereferences a NULL pointer when trying to download the database signature.
+Server = https://archlinux.qubes-os.org/r4.2/current/vm/archlinux/pkgs
+SigLevel = Required TrustedOnly

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -111,7 +111,7 @@ package_qubes-vm-core() {
     mkdir -p -m 0755 "${pkgdir}/etc/pacman.d"
     install -m 644 "archlinux/PKGBUILD-qubes-pacman-options.conf" "${pkgdir}/etc/pacman.d/10-qubes-options.conf"
     echo "Installing repository for release ${release}"
-    install -m 644 "archlinux/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
+    install -m 644 "archlinux/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf"
 
     # Install upgrade check scripts
     install -m 0755 "package-managers/upgrades-installed-check" "${pkgdir}/usr/lib/qubes/"


### PR DESCRIPTION
I'm not sure whether to have the testing repository uncommented or not, given that Arch is a rolling release distribution.  The duplicated Server= line is a workaround for a libalpm bug that causes Pacman to segfault.