### PR TITLE
Remove Arch repository stub

### DIFF
--- a/archlinux/PKGBUILD-qubes-repo-4.2.conf
+++ b/archlinux/PKGBUILD-qubes-repo-4.2.conf
@@ -1,3 +1,0 @@
-[qubes-r4.2]
-#Replace the server below with your own
-#Server = https://YOUR_OWN_SERVER

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -110,8 +110,6 @@ package_qubes-vm-core() {
     # Install pacman.d drop-ins (at least 1 drop-in must be installed or pacman will fail)
     mkdir -p -m 0755 "${pkgdir}/etc/pacman.d"
     install -m 644 "archlinux/PKGBUILD-qubes-pacman-options.conf" "${pkgdir}/etc/pacman.d/10-qubes-options.conf"
-    echo "Installing repository for release ${release}"
-    install -m 644 "archlinux/PKGBUILD-qubes-repo-${release}.conf" "${pkgdir}/etc/pacman.d/99-qubes-repository-${release}.conf.disabled"
 
     # Install upgrade check scripts
     install -m 0755 "package-managers/upgrades-installed-check" "${pkgdir}/usr/lib/qubes/"


### PR DESCRIPTION
The actual repositories are installed via the meta-packages git repository.