### PR TITLE
pacman hook to notify dom0 about successful upgrade

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -108,6 +108,9 @@ package_qubes-vm-core() {
     mkdir -p "${pkgdir}/usr/share/libalpm/hooks/"
     install -m 644 "archlinux/PKGBUILD.qubes-update-desktop-icons.hook" "${pkgdir}/usr/share/libalpm/hooks/qubes-update-desktop-icons.hook"
 
+    # Install pacman hook to notify dom0 about successful upgrade
+    install -m 644 "archlinux/PKGBUILD.qubes-post-upgrade.hook" "${pkgdir}/usr/share/libalpm/hooks/qubes-post-upgrade.hook"
+
     # Install pacman.d drop-ins (at least 1 drop-in must be installed or pacman will fail)
     mkdir -p -m 0755 "${pkgdir}/etc/pacman.d"
     install -m 644 "archlinux/PKGBUILD-qubes-pacman-options.conf" "${pkgdir}/etc/pacman.d/10-qubes-options.conf"

--- a/archlinux/PKGBUILD.qubes-post-upgrade.hook
+++ b/archlinux/PKGBUILD.qubes-post-upgrade.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Upgrade
+Type = Path
+Target = *
+
+[Action]
+Description = Notifying dom0 about successful upgrade...
+Depends = qubes-vm-qrexec
+When = PostTransaction
+Exec = /usr/lib/qubes/qrexec-client-vm dom0 qubes.NotifyUpdates /bin/sh -c 'echo 0'


### PR DESCRIPTION
Resetting `updates-available` feature of Archlinux template after successful upgrades

Reference to issue: Fixes QubesOS/qubes-issues#9233