### PR TITLE
Do not use python-daemon library

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,7 +41,6 @@ Depends:
     util-linux,
     e2fsprogs,
     parted,
-    python3-daemon,
     python3-qubesdb,
     python3-gi,
     python3-xdg,

--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -27,7 +27,6 @@ import ipaddress
 import subprocess
 import pwd
 import shutil
-import daemon
 
 import qubesdb
 import sys
@@ -635,15 +634,8 @@ def main():
     else:
         print('Sorry, iptables no longer supported', file=sys.stderr)
         sys.exit(1)
-    context = daemon.DaemonContext()
-    context.stderr = sys.stderr
-    context.detach_process = False
-    context.files_preserve = [worker.qdb.watch_fd()]
-    context.signal_map = {
-        signal.SIGTERM: lambda _signal, _stack: worker.terminate(),
-    }
-    with context:
-        worker.main()
+    signal.signal(signal.SIGTERM, lambda _signal, _stack: worker.terminate())
+    worker.main()
 
 
 if __name__ == '__main__':

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -146,11 +146,6 @@ Requires:   python%{python3_pkgversion}-dbus
 %endif
 # for qubes-session-autostart, xdg-icon
 Requires:   python%{python3_pkgversion}-pyxdg
-%if 0%{?is_opensuse}
-Requires:   python%{python3_pkgversion}-python-daemon
-%else
-Requires:   python%{python3_pkgversion}-daemon
-%endif
 # for qvm-feature-request
 Requires:   python%{python3_pkgversion}-qubesdb
 # for qubes.ShowInTerminal RPC service


### PR DESCRIPTION
It was relevant when qubes-firewall was started from SysV init script,
but it isn't the case anymore. Most of its features were disabled
anyway, and redirecting stdin/out/err is handled by systemd anyway.

This is the last usage of the library which isn't available in
Archlinux, and as such qubes-firewall service was broken there. Not
using this library should fix the issue.

Fixes QubesOS/qubes-issues#9238