### PR TITLE
Use allow-all-names instead of allow-unsafe-characters

### DIFF
--- a/qubes-rpc/qfile-unpacker.c
+++ b/qubes-rpc/qfile-unpacker.c
@@ -72,8 +72,8 @@ enum {
 };
 
 const struct option opts[] = {
-    { "no-allow-unsafe-characters", no_argument, NULL, opt_no_allow_unsafe_characters },
-    { "allow-unsafe-characters", no_argument, NULL, opt_allow_unsafe_characters },
+    { "no-allow-all-names", no_argument, NULL, opt_no_allow_unsafe_characters },
+    { "allow-all-names", no_argument, NULL, opt_allow_unsafe_characters },
     { "no-allow-unsafe-symlinks", no_argument, NULL, opt_no_allow_unsafe_symlinks },
     { "allow-unsafe-symlinks", no_argument, NULL, opt_allow_unsafe_symlinks },
     { "verbose", no_argument, NULL, 'v' },

--- a/qubes-rpc/qubes-fs-tree-check.c
+++ b/qubes-rpc/qubes-fs-tree-check.c
@@ -191,8 +191,8 @@ const struct option opts[] = {
     {"no-allow-symlinks", no_argument, NULL, 'A'},
     {"allow-directories", no_argument, NULL, 'd'},
     {"no-allow-directories", no_argument, NULL, 'D'},
-    {"allow-unsafe-characters", no_argument, NULL, 'u'},
-    {"no-allow-unsafe-characters", no_argument, NULL, 'U'},
+    {"allow-all-names", no_argument, NULL, 'u'},
+    {"no-allow-all-names", no_argument, NULL, 'U'},
     {0, 0, NULL, 0},
 };
 

--- a/qubes-rpc/qubes.Filecopy
+++ b/qubes-rpc/qubes.Filecopy
@@ -5,7 +5,7 @@ then
 fi
 case $1 in
 ('') arg=;;
-(allow-unsafe-characters) arg=--allow-unsafe-characters;;
+(allow-all-names) arg=--allow-all-names;;
 (*) printf 'Unexpected argument %s\n' "$1" >&2; exit 1;;
 esac
 exec /usr/lib/qubes/qfile-unpacker $arg

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -88,7 +88,7 @@ if FILECOPY_TOTAL_SIZE=$("$scriptdir/qubes/qubes-fs-tree-check" \
 else
     status=$?
     if [[ "$status" -ne 2 ]]; then exit "$status"; fi
-    service=qubes.Filecopy+allow-unsafe-characters
+    service=qubes.Filecopy+allow-all-names
 fi
 if [[ "$PROGRESS_TYPE" = 'console' ]]; then export FILECOPY_TOTAL_SIZE; fi
 


### PR DESCRIPTION
As pointed out by Andrew David Wong the latter name is unnecessarily alarming.  No backwards compatibility is provided because users should not need to remember to blocklist two different strings in their qrexec policies.  Denying "+allow-all-names" should be sufficient.

Reported-by: Andrew David Wong <adw@qubes-os.org>
Fixes: QubesOS/qubes-issues#8332 (for real this time)