### PR TITLE
Remove redundant qubes-dom0-update message

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -107,7 +107,6 @@ fi
 
 # just check for updates, but don't download any package
 if [ ${#PKGLIST[@]} -eq 0 ] && [ "$CHECK_ONLY" = "1" ]; then
-    echo "Checking for dom0 updates..." >&2
     # shellcheck disable=SC2086
     UPDATES_FULL=$("${YUM[@]}" "${OPTS[@]}" check-update)
     check_update_retcode=$?


### PR DESCRIPTION
Message for --check-only is moved to qubes-dom0-update 
main fix: https://github.com/QubesOS/qubes-core-admin-linux/pull/162
original issue: https://github.com/QubesOS/qubes-issues/issues/6126