### PR TITLE
Configure DNF5 to execute post-update actions

### DIFF
--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -39,7 +39,7 @@ endif
 
 DIST ?= fc33
 
-.PHONY: install install-apt install-dnf install-rpm install-yum
+.PHONY: install install-apt install-dnf install-dnf5 install-rpm install-yum
 
 install:
 	install -d $(DESTDIR)$(QUBESLIBDIR)
@@ -90,6 +90,10 @@ else
 		$(DESTDIR)$(PYTHON3_SITELIB)/dnf-plugins/qubes-hooks.py
 endif
 	install -D -m 0644 dnf-qubes-hooks.conf $(DESTDIR)$(SYSCONFDIR)/dnf/plugins/qubes-hooks.conf
+
+install-dnf5: install-rpm
+	install -D -m 0644 qubes-post-update.actions \
+		$(DESTDIR)$(SYSCONFDIR)/dnf/libdnf5-plugins/actions.d/qubes-post-update.actions
 
 install-yum: install-rpm
 	install -d $(DESTDIR)$(LIBDIR)/yum-plugins

--- a/package-managers/qubes-post-update.actions
+++ b/package-managers/qubes-post-update.actions
@@ -1,0 +1,4 @@
+# notify dom0 if all updates are installed now
+post_transaction:::enabled=host-only:/usr/lib/qubes/upgrades-status-notify
+# refresh appmenus, features etc
+post_transaction:::enabled=host-only:/etc/qubes-rpc/qubes.PostInstall

--- a/qubes-rpc/qvm-template-repo-query
+++ b/qubes-rpc/qvm-template-repo-query
@@ -26,11 +26,18 @@ repodir=$(mktemp -d)
 trap 'rm -r "$repodir"' EXIT
 cat > "$repodir/template.repo"
 
+DNF5=false
+if [ "$(readlink /usr/bin/dnf)" = "dnf5" ]; then
+    DNF5=true
+fi
+
 OPTS+=(-y "--setopt=reposdir=${repodir}" --quiet)
 
-# use vendored 'downloadurl' dnf-plugin (fork of 'download' plugin), to print
-# all mirrors
-OPTS+=("--setopt=pluginpath=/usr/lib/qubes/dnf-plugins")
+if ! $DNF5; then
+    # use vendored 'downloadurl' dnf-plugin (fork of 'download' plugin), to print
+    # all mirrors
+    OPTS+=("--setopt=pluginpath=/usr/lib/qubes/dnf-plugins")
+fi
 
 if ! command -v dnf >/dev/null; then
     echo "ERROR: dnf command is missing, please use newer template for your UpdateVM to download templates." >&2

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -201,6 +201,7 @@ BuildRequires: qubes-utils-devel >= 4.3.1
 BuildRequires: qubes-libvchan-%{?qubes_backend_vmm}%{?!qubes_backend_vmm:@BACKEND_VMM@}-devel
 BuildRequires: pam-devel
 BuildRequires: python%{python3_pkgversion}-setuptools
+BuildRequires: python%{python3_pkgversion}-devel
 BuildRequires: systemd
 %if 0%{?rhel} >= 8
 BuildRequires: redhat-lsb
@@ -230,6 +231,8 @@ Requires: (gnome-keyring if xdg-desktop-portal)
 %description
 The Qubes core files for installation inside a Qubes VM.
 
+%if 0%{?fedora} < 41
+# not relevant anymore with DNF5
 %if 0%{?rhel} == 8
 %package -n python3-dnf-plugins-qubes-hooks
 Summary: DNF plugin for Qubes specific post-installation actions
@@ -256,6 +259,7 @@ BuildArch: noarch
 DNF plugin for Qubes specific post-installation actions:
  * notify dom0 that updates were installed
  * refresh applications shortcut list
+%endif
 %endif
 
 %if 0%{?rhel} != 7
@@ -964,8 +968,8 @@ rm -f %{name}-%{version}
 /etc/yum/pluginconf.d/yum-qubes-hooks.conf
 /usr/lib/yum-plugins/yum-qubes-hooks.py*
 %endif
-%endif
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
+%endif
 %dir /etc/dconf/db/local.d
 %config(noreplace) /etc/dconf/db/local.d/dpi
 %config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
@@ -1066,12 +1070,15 @@ rm -f %{name}-%{version}
 %dir /mnt/removable
 %dir /rw
 
+%if 0%{?fedora} < 41
+# not relevant anymore with DNF5
 %if 0%{?rhel} == 8
 %files -n python3-dnf-plugins-qubes-hooks
 %{plateform_python3_sitelib}/dnf-plugins/*
 %else
 %files -n python%{python3_pkgversion}-dnf-plugins-qubes-hooks
 %{python3_sitelib}/dnf-plugins/*
+%endif
 %endif
 
 %if 0%{?rhel} != 7

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -167,12 +167,16 @@ Requires:   dbus-1-tools
 %else
 Requires:   dbus-tools
 %endif
+%if 0%{?fedora} >= 41
+Requires:   libdnf5-plugin-actions
+%else
 %if 0%{?rhel} == 8
 # we need to stick to related DNF python version
 # which is python3.6 by default
 Requires:   python3-dnf-plugins-qubes-hooks
 %else
 Requires:   python%{python3_pkgversion}-dnf-plugins-qubes-hooks
+%endif
 %endif
 Requires:   python%{python3_pkgversion}-setuptools
 # for qubes.ResizeDisk
@@ -496,7 +500,11 @@ make -C qubes-rpc/kde DESTDIR=$RPM_BUILD_ROOT install-kde5
 make -C qubes-rpc/nautilus DESTDIR=$RPM_BUILD_ROOT install
 make -C qubes-rpc/thunar DESTDIR=$RPM_BUILD_ROOT install
 
+%if 0%{?fedora} >= 41
+make -C package-managers PYTHON=%{__python3} DESTDIR=$RPM_BUILD_ROOT install install-dnf5
+%else
 make -C package-managers PYTHON=%{__python3} DESTDIR=$RPM_BUILD_ROOT install install-dnf
+%endif
 %if 0%{?rhel} == 7
 make -C package-managers DESTDIR=$RPM_BUILD_ROOT install-yum
 %endif
@@ -949,9 +957,13 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/yum.conf.d/qubes-proxy.conf
 %dir /etc/yum.repos.d
 %config(noreplace) /etc/yum.repos.d/qubes-r4.repo
+%if 0%{?fedora} >= 41
+/etc/dnf/libdnf5-plugins/actions.d/qubes-post-update.actions
+%else
 %if 0%{?rhel} == 7
 /etc/yum/pluginconf.d/yum-qubes-hooks.conf
 /usr/lib/yum-plugins/yum-qubes-hooks.py*
+%endif
 %endif
 %config(noreplace) /etc/dnf/plugins/qubes-hooks.conf
 %dir /etc/dconf/db/local.d


### PR DESCRIPTION
DNF4 plugin we used to have for this doesn't work in Fedora 41 anymore. Use libdnf5-plugin-actions in DNF5.

QubesOS/qubes-issues#9244