### PR TITLE
Limit initramfs size in Fedora HVM even more

### DIFF
--- a/boot/dracut-qubes.conf
+++ b/boot/dracut-qubes.conf
@@ -10,3 +10,7 @@ drivers="xen-blkfront dm-mod dm-thin-pool dm-persistent-data ext4 overlay"
 # Remove also other modules not relevant for qubes VM, due to known filesystem
 # setup, and not interacting with VGA console during boot.
 omit_dracutmodules+=" ifcfg qemu-net i18n resume mdraid terminfo crypt lunmask nvdimm nss-softokn "
+# Exclude tpm stack too, as it's irrelevant for a VM (at least as long as
+# confidential computing is not a Qubes feature). This saves about 5MB (20%) of
+# initramfs size.
+omit_dracutmodules+=" tpm2-tss "


### PR DESCRIPTION
Initramfs at 22MB is small enough to start in PVH mode, but too big to
start in HVM mode. Exclude tpm2-tss dracut module to save another 5MB,
which makes it work in HVM mode too.

QubesOS/qubes-issues#8540
QubesOS/qubes-issues#5212