### PR TITLE
qvm-copy: support `--ignore-symlinks` and honor `--`

### DIFF
--- a/qubes-rpc/qfile-agent.c
+++ b/qubes-rpc/qfile-agent.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <gui-fatal.h>
 #include <libqubes-rpc-filecopy.h>
 
@@ -82,10 +83,17 @@ int main(int argc, char **argv)
     invocation_cwd_fd = open(".", O_PATH | O_DIRECTORY);
     if (invocation_cwd_fd < 0)
         gui_fatal("open \".\"");
+    bool ignore_options = false;
     for (i = 1; i < argc; i++) {
-        if (strcmp(argv[i], "--ignore-symlinks")==0) {
-            ignore_symlinks = 1;
-            continue;
+        if (!ignore_options) {
+            if (strcmp(argv[i], "--ignore-symlinks")==0) {
+                ignore_symlinks = 1;
+                continue;
+            }
+            if (strcmp(argv[i], "--") == 0) {
+                ignore_options = true;
+                continue;
+            }
         }
         if (!*argv[i])
             gui_fatal("Invalid empty argument %i", i);

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -21,7 +21,7 @@
 
 set -e -o pipefail
 
-unset PROGRESS_TYPE OPERATION_TYPE TARGET_TYPE MIN_ARGS FILECOPY_TOTAL_BYTES service scriptdir
+unset PROGRESS_TYPE OPERATION_TYPE TARGET_TYPE MIN_ARGS FILECOPY_TOTAL_BYTES service scriptdir ignore_symlinks
 
 # Determine the operation to be performed
 case ${0##*/} in
@@ -41,9 +41,9 @@ esac
 
 usage () {
     if [ "$TARGET_TYPE" = "vm" ]; then
-        echo "usage: $0 [--without-progress] destination_qube_name FILE [FILE ...]"
+        echo "usage: $0 [--without-progress] [--ignore-symlinks] destination_qube_name FILE [FILE ...]"
     else
-        echo "usage: $0 [--without-progress] FILE [FILE ...]"
+        echo "usage: $0 [--without-progress] [--ignore-symlinks] FILE [FILE ...]"
     fi
 
     echo
@@ -66,6 +66,7 @@ export PROGRESS_TYPE=console
 while [ "$#" -gt 0 ]; do
     case $1 in
         (--without-progress) export PROGRESS_TYPE=none; shift;;
+        (--ignore-symlinks) ignore_symlinks=true; shift;;
         (-h|--help) usage 0;;
         (--) shift; break;;
         (-*) usage 1;;
@@ -93,7 +94,7 @@ fi
 if [[ "$PROGRESS_TYPE" = 'console' ]]; then export FILECOPY_TOTAL_BYTES; fi
 
 "$scriptdir/qubes/qrexec-client-vm" --filter-escape-chars-stderr -- "$VM" \
-    "$service" "$scriptdir/qubes/qfile-agent" "$@"
+    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks+--ignore-symlinks} -- "$@"
 
 if [ "$OPERATION_TYPE" = "move" ] ; then
     rm -rf -- "$@"

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -45,8 +45,13 @@ usage () {
     else
         echo "usage: $0 [--without-progress] [--ignore-symlinks] FILE [FILE ...]"
     fi
+    echo 'Options:
+    --ignore-symlinks      Ignore symbolic links.
+    --without-progress     Do not show a progress indicator.
+    -h, --help             Show this message and exit.
+    --                     Stop searching for options.
 
-    echo
+'
 
     if [ "$OPERATION_TYPE" = "move" ]; then
         echo "Move FILE to ~/QubesIncoming/[THIS QUBE'S NAME]/ in the destination qube."

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -46,11 +46,14 @@ usage () {
         echo "usage: $0 [--without-progress] [--ignore-symlinks] FILE [FILE ...]"
     fi
     echo 'Options:
+    --no-ignore-symlinks   Do not ignore symbolic links (default).
     --ignore-symlinks      Ignore symbolic links.
+    --with-progress        Show a progress indicator (default).
     --without-progress     Do not show a progress indicator.
     -h, --help             Show this message and exit.
     --                     Stop searching for options.
 
+    If there is a conflict, later options override earlier options.
 '
 
     if [ "$OPERATION_TYPE" = "move" ]; then
@@ -71,7 +74,9 @@ export PROGRESS_TYPE=console
 while [ "$#" -gt 0 ]; do
     case $1 in
         (--without-progress) export PROGRESS_TYPE=none; shift;;
+        (--with-progress) export PROGRESS_TYPE=console; shift;;
         (--ignore-symlinks) ignore_symlinks=true; shift;;
+        (--no-ignore-symlinks) unset ignore_symlinks; shift;;
         (-h|--help) usage 0;;
         (--) shift; break;;
         (-*) usage 1;;


### PR DESCRIPTION
`--` was stripped from the arguments before being passed to qfile-agent, so `qvm-copy -- --ignore-symlinks` would ignore symlinks instead of copying a file named `--ignore-symlinks`.  To fix this problem, always pass `--` to qfile-agent, preceeded by `--ignore-symlinks` if necessary.  This requires qfile-agent to honor `--` as indicating end of options, so patch it to do that.
