### PR TITLE
Adjust default process/threads limit

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -56,6 +56,7 @@ etc/qubes/rpc-config/qubes.VMExecGUI
 etc/qubes/suspend-post.d/README
 etc/qubes/suspend-post.d/*.sh
 etc/qubes/suspend-pre.d/README
+etc/security/limits.d/90-qubes-core.conf
 etc/sudoers.d/qt_x11_no_mitshm
 etc/sudoers.d/umask
 etc/sysctl.d/20_tcp_timestamps.conf
@@ -106,6 +107,7 @@ lib/systemd/system/sysinit.target.d/30_qubes.conf
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
+usr/lib/sysctl.d/20-qubes-core.conf
 usr/lib/systemd/user/tracker-extract-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-miner-fs-3.service.d/30_qubes.conf
 usr/lib/systemd/user/tracker-miner-fs-control-3.service.d/30_qubes.conf

--- a/misc/20-qubes-core.conf
+++ b/misc/20-qubes-core.conf
@@ -1,0 +1,5 @@
+# With memory hotplug enabled, default value is calculated based on the initial
+# memory, and is too low for some heavy multi-threads applications like
+# Firefox. Raise the limit
+
+kernel.threads-max = 51200

--- a/misc/90-qubes-core.conf
+++ b/misc/90-qubes-core.conf
@@ -1,0 +1,5 @@
+# With memory hotplug enabled, default value is calculated based on the initial
+# memory, and is too low (below 1000) for some heavy multi-threads applications
+# like Firefox. Raise the limit
+@qubes  hard nproc 51200
+@qubes  soft nproc 51200

--- a/misc/Makefile
+++ b/misc/Makefile
@@ -52,6 +52,8 @@ install:
 	install -m 0755 -d $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml
 	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml xfce4-notifyd.xml
 	install -m 0644 -t $(DESTDIR)/etc/xdg/xfce4/xfconf/xfce-perchannel-xml displays.xml
+	install -m 0644 -D -t $(DESTDIR)/etc/security/limits.d 90-qubes-core.conf
+	install -m 0644 -D -t $(DESTDIR)/usr/lib/sysctl.d 20-qubes-core.conf
 
 marker-vm: marker-vm.in
 	printf "$(VERSION)" | cut -f 1,2 -d . | cat $< - > marker-vm

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -974,6 +974,8 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/dconf/db/local.d/dpi
 %config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/xfce4-notifyd.xml
 %config(noreplace) /etc/xdg/xfce4/xfconf/xfce-perchannel-xml/displays.xml
+%config(noreplace) /etc/security/limits.d/90-qubes-core.conf
+/usr/lib/sysctl.d/20-qubes-core.conf
 %_udevrulesdir/50-qubes-mem-hotplug.rules
 %_unitdir/user@.service.d/90-session-stop-timeout.conf
 /usr/sbin/qubes-serial-login


### PR DESCRIPTION
When VM is started with memory hotplug, the initial memory size is quite
small. It is used for calculating default threads limit, and that in
turns is used to calculate default process count limit per user. For a
VM started with 400MB (the default) both limits are too low for some
threads/processes-heavy applications like Firefox.

Adjust the limits to a static higher value, based on defaults when
memory hotplug is disabled (and rounded to a nice number).

Fixes QubesOS/qubes-issues#8960