### PR TITLE
debian: use polkitd instead of policykit-1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -163,7 +163,7 @@ Depends:
     libglib2.0-bin,
     network-manager (>= 0.8.1-1),
     network-manager-gnome,
-    policykit-1
+    polkitd | policykit-1
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: NetworkManager integration for Qubes VM


### PR DESCRIPTION
In bookworm, `policykit-1` is now a “transitional package”.

For example, see [Debian Changelog for network-manager](https://metadata.ftp-master.debian.org/changelogs//main/n/network-manager/network-manager_1.42.4-1_changelog):
1.40.6-1
  * Depend on polkitd in preference to policykit-1.
    The latter is a deprecated, transitional package, that also pulls in
    pkexec, which network-manager doesn't need. Keep policykit-1 as an
    alternative dependency to make backports easier.
