### PR TITLE
Sync other systemd /tmp mount options with Fedora

### DIFF
--- a/vm-systemd/tmp.mount.d/30_qubes.conf
+++ b/vm-systemd/tmp.mount.d/30_qubes.conf
@@ -1,4 +1,4 @@
 [Mount]
 # Default initial size is '50%' (of physical RAM at system startup)
 # Because of memory ballooning this happen to be very low number
-Options=mode=1777,strictatime,size=1G
+Options=mode=1777,strictatime,nosuid,nodev,size=1G,nr_inodes=1m


### PR DESCRIPTION
The Qubes config for systemd /tmp mount options overrides the size of /tmp due to memory ballooning. However, it only copies some of the other options. This patch syncs with Fedora by also adding the options nosuid,nodev,nr_inodes=1m. Setting nosuid and nodev should have minor security benefits.

Increasing nr_inodes is important because otherwise the default is nr_inodes=44492, which is too few inodes for software like "opam" which uses /tmp as a staging directory.