### PR TITLE
SystemD dropins for minimal sys-net and sys-usb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,7 @@ endif
 
 # Systemd service files
 SYSTEMD_ALL_SERVICES := $(wildcard vm-systemd/qubes-*.service) vm-systemd/dev-xvdc1-swap.service
-SYSTEMD_NETWORK_SERVICES := vm-systemd/qubes-firewall.service vm-systemd/qubes-iptables.service vm-systemd/qubes-updates-proxy.service vm-systemd/qubes-antispoof.service
+SYSTEMD_NETWORK_SERVICES := vm-systemd/qubes-firewall.service vm-systemd/qubes-iptables.service vm-systemd/qubes-updates-proxy.service vm-systemd/qubes-antispoof.service vm-systemd/qubes-sysctl-minimal-sys-net.service
 SYSTEMD_SELINUX_SERVICES := vm-systemd/qubes-relabel-root.service vm-systemd/qubes-relabel-rw.service
 SYSTEMD_CORE_SERVICES := $(filter-out $(SYSTEMD_NETWORK_SERVICES) $(SYSTEMD_SELINUX_SERVICES), $(SYSTEMD_ALL_SERVICES))
 
@@ -207,6 +207,7 @@ install-common: install-doc
 install-networking:
 	install -d $(DESTDIR)/etc/sysctl.d
 	install -m 644 network/81-qubes.conf.optional $(DESTDIR)/etc/sysctl.d/
+	install -m 644 network/82-qubes-minimal-sys-net.conf.optional $(DESTDIR)/etc/sysctl.d/
 	install -d $(DESTDIR)$(SYSLIBDIR)/systemd/system
 	install -m 0644 vm-systemd/qubes-*.socket $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ SYSTEM_DROPINS += sysinit.target
 ifeq ($(ENABLE_SELINUX),1)
 SYSTEM_DROPINS += selinux-autorelabel.target selinux-autorelabel.service
 endif
+SYSTEM_DROPINS += polkit.service
+SYSTEM_DROPINS += abrtd.service
+SYSTEM_DROPINS += bluetooth.service
 
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service
@@ -68,7 +71,12 @@ USER_DROPINS := \
 	evolution-addressbook-factory.service \
 	evolution-calendar-factory.service \
 	evolution-source-registry.service \
-	evolution-user-prompter.service
+	evolution-user-prompter.service \
+	pipewire.service \
+	gvfs-daemon.service \
+	at-spi-dbus-bus.service \
+	wireplumber.service
+
 
 # Ubuntu Dropins
 ifeq ($(release),Ubuntu)

--- a/debian/qubes-core-agent-networking.install
+++ b/debian/qubes-core-agent-networking.install
@@ -6,6 +6,7 @@ etc/qubes/qubes-ipv6.nft
 etc/qubes/qubes-ipv4.nft
 etc/qubes/qubes-antispoof.nft
 etc/sysctl.d/81-qubes.conf.optional
+etc/sysctl.d/82-qubes-minimal-sys-net.conf.optional
 etc/tinyproxy/tinyproxy-updates.conf
 etc/tinyproxy/updates-blacklist
 etc/udev/rules.d/99-qubes-network.rules
@@ -17,6 +18,7 @@ lib/systemd/system/qubes-antispoof.service
 lib/systemd/system/qubes-network.service
 lib/systemd/system/qubes-network-uplink.service
 lib/systemd/system/qubes-network-uplink@.service
+lib/systemd/system/qubes-sysctl-minimal-sys-net.service
 lib/systemd/system/qubes-updates-proxy.service
 lib/systemd/network/80-qubes-vif.link
 usr/lib/qubes/init/network-proxy-setup.sh

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -70,9 +70,11 @@ lib/systemd/system/boot.automount.d/30_qubes.conf
 lib/systemd/system/ModemManager.service.d/30_qubes.conf
 lib/systemd/system/NetworkManager-wait-online.service.d/30_qubes.conf
 lib/systemd/system/NetworkManager.service.d/30_qubes.conf
+lib/systemd/system/abrtd.service.d/30_qubes.conf
 lib/systemd/system/anacron-resume.service.d/30_qubes.conf
 lib/systemd/system/anacron.service.d/30_qubes.conf
 lib/systemd/system/avahi-daemon.service.d/30_qubes.conf
+lib/systemd/system/bluetooth.service.d/30_qubes.conf
 lib/systemd/system/chronyd.service.d/30_qubes.conf
 lib/systemd/system/cron.service.d/30_qubes.conf
 lib/systemd/system/cups.path.d/30_qubes.conf
@@ -85,6 +87,7 @@ lib/systemd/system/netfilter-persistent.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.path.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.socket.d/30_qubes.conf
+lib/systemd/system/polkit.service.d/30_qubes.conf
 lib/systemd/system/dev-xvdc1-swap.service
 lib/systemd/system/qubes-early-vm-config.service
 lib/systemd/system/qubes-misc-post.service
@@ -118,6 +121,10 @@ usr/lib/systemd/user/evolution-addressbook-factory.service.d/30_qubes.conf
 usr/lib/systemd/user/evolution-calendar-factory.service.d/30_qubes.conf
 usr/lib/systemd/user/evolution-source-registry.service.d/30_qubes.conf
 usr/lib/systemd/user/evolution-user-prompter.service.d/30_qubes.conf
+usr/lib/systemd/user/at-spi-dbus-bus.service.d/30_qubes.conf
+usr/lib/systemd/user/gvfs-daemon.service.d/30_qubes.conf
+usr/lib/systemd/user/pipewire.service.d/40_minimal.conf
+usr/lib/systemd/user/wireplumber.service.d/30_qubes.conf
 lib/udev/rules.d/50-qubes-mem-hotplug.rules
 usr/bin/qfile-unpacker
 usr/bin/qubes-desktop-run

--- a/network/82-qubes-minimal-sys-net.conf.optional
+++ b/network/82-qubes-minimal-sys-net.conf.optional
@@ -1,0 +1,8 @@
+# Keep RAM for kernel data structures to prevent page allocation
+# failures when running minimal sys-net
+
+vm.dirty_background_ratio = 5
+vm.dirty_ratio = 10
+vm.dirty_expire_centisecs = 250
+vm.min_free_kbytes = 20480
+vm.zone_reclaim_mode = 3

--- a/qubes-rpc/post-install.d/10-qubes-core-agent-features.sh
+++ b/qubes-rpc/post-install.d/10-qubes-core-agent-features.sh
@@ -104,6 +104,8 @@ if [ -e /etc/xdg/autostart/blueman.desktop ]; then
 fi
 
 qvm-features-request supported-service.no-qubesincoming-cleanup=1
+qvm-features-request supported-service.minimal-netvm=1
+qvm-features-request supported-service.minimal-usbvm=1
 
 # native services plugged into qubes-services with systemd drop-ins, list them
 # only when actual service is installed
@@ -134,4 +136,3 @@ advertise_systemd_service qubes-updates-proxy qubes-updates-proxy.service
 advertise_systemd_service qubes-firewall qubes-firewall.service
 advertise_systemd_service qubes-network qubes-network.service
 advertise_systemd_service apparmor apparmor.service
-

--- a/qubes-rpc/prepare-suspend
+++ b/qubes-rpc/prepare-suspend
@@ -81,6 +81,12 @@ if [ "$action" = "suspend" ]; then
     done
     echo "$LOADED_MODULES" > /var/run/qubes-suspend-modules-loaded
 else
+    # Free some RAM for minimal netvm to prevent memory issues when loading
+    # drivers
+    if [ -f /var/run/qubes-service/minimal-netvm ]; then
+      sync
+      echo 3 > /proc/sys/vm/drop_caches
+    fi
     # shellcheck disable=SC2013
     for mod in $(cat /var/run/qubes-suspend-modules-loaded); do
         modprobe "$mod"

--- a/qubes-rpc/qubes-suspend-module-blacklist
+++ b/qubes-rpc/qubes-suspend-module-blacklist
@@ -6,3 +6,4 @@ ehci_pci
 xhci_pci
 iwldvm
 iwlmvm
+iwlwifi

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1274,6 +1274,8 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/qubes-updates-proxy-forwarder.socket
 %{_unitdir}-preset/%qubes_preset_file
 %_modulesloaddir/qubes-core.conf
+%_unitdir/abrtd.service.d/30_qubes.conf
+%_unitdir/bluetooth.service.d/30_qubes.conf
 %dir %_unitdir/boot.automount.d
 %_unitdir/boot.automount.d/30_qubes.conf
 %dir %_unitdir/*.service.d
@@ -1294,6 +1296,7 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/ModemManager.service.d/30_qubes.conf
 %_unitdir/NetworkManager.service.d/30_qubes.conf
 %_unitdir/NetworkManager-wait-online.service.d/30_qubes.conf
+%_unitdir/polkit.service.d/30_qubes.conf
 %_unitdir/serial-getty@.service.d/30_qubes.conf
 %_unitdir/systemd-random-seed.service.d/30_qubes.conf
 %_unitdir/systemd-timesyncd.service.d/30_qubes.conf
@@ -1316,6 +1319,10 @@ The Qubes core startup configuration for SystemD init.
 %_userunitdir/evolution-calendar-factory.service.d/30_qubes.conf
 %_userunitdir/evolution-source-registry.service.d/30_qubes.conf
 %_userunitdir/evolution-user-prompter.service.d/30_qubes.conf
+%_userunitdir/at-spi-dbus-bus.service.d/30_qubes.conf
+%_userunitdir/gvfs-daemon.service.d/30_qubes.conf
+%_userunitdir/pipewire.service.d/40_minimal.conf
+%_userunitdir/wireplumber.service.d/30_qubes.conf
 
 %post systemd
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1120,6 +1120,7 @@ rm -f %{name}-%{version}
 
 %files networking
 %config /etc/sysctl.d/81-qubes.conf.optional
+%config /etc/sysctl.d/82-qubes-minimal-sys-net.conf.optional
 %config(noreplace) /etc/qubes-rpc/qubes.UpdatesProxy
 %config(noreplace) /etc/qubes/qubes-antispoof.nft
 %config(noreplace) /etc/qubes/qubes-ipv4.nft
@@ -1140,6 +1141,7 @@ rm -f %{name}-%{version}
 %_unitdir/qubes-network.service
 %_unitdir/qubes-network-uplink.service
 %_unitdir/qubes-network-uplink@.service
+%_unitdir/qubes-sysctl-minimal-sys-net.service
 %_unitdir/qubes-updates-proxy.service
 /usr/lib/systemd/network/80-qubes-vif.link
 /usr/lib/qubes/init/network-proxy-setup.sh

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -114,6 +114,7 @@ enable qubes-psu-client@.service default sys-usb
 enable dev-xvdc1-swap.service
 enable NetworkManager.service
 enable NetworkManager-dispatcher.service
+enable qubes-sysctl-minimal-sys-net.service
 
 # Disable useless Xen services in Qubes VM
 disable xenstored.service

--- a/vm-systemd/abrtd.service.d/30_qubes.conf
+++ b/vm-systemd/abrtd.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/bluetooth.service.d/30_qubes.conf
+++ b/vm-systemd/bluetooth.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/polkit.service.d/30_qubes.conf
+++ b/vm-systemd/polkit.service.d/30_qubes.conf
@@ -1,0 +1,2 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/qubes-sysctl-minimal-sys-net.service
+++ b/vm-systemd/qubes-sysctl-minimal-sys-net.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Apply minimal sys-net kernel variables
+DefaultDependencies=no
+Conflicts=shutdown.target
+After=systemd-modules-load.service qubes-sysinit.service
+Before=sysinit.target shutdown.target
+ConditionPathIsReadWrite=/proc/sys/net/
+ConditionPathExists=/var/run/qubes-service/minimal-netvm
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/lib/systemd/systemd-sysctl /etc/sysctl.d/82-qubes-minimal-sys-net.conf.optional
+TimeoutSec=90s
+ImportCredential=sysctl.*
+
+[Install]
+WantedBy=sysinit.target

--- a/vm-systemd/user/at-spi-dbus-bus.service.d/30_qubes.conf
+++ b/vm-systemd/user/at-spi-dbus-bus.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/user/gvfs-daemon.service.d/30_qubes.conf
+++ b/vm-systemd/user/gvfs-daemon.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/user/pipewire.service.d/40_minimal.conf
+++ b/vm-systemd/user/pipewire.service.d/40_minimal.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/user/wireplumber.service.d/30_qubes.conf
+++ b/vm-systemd/user/wireplumber.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm


### PR DESCRIPTION
Some unnecessary services are running on sys-net and sys-usb which consumes RAM for nothing. SystemD dropins are added to automatically disable identified unecessary services by enabling minimal-netvm or minimal-usbvm  service on the sys-vms with qvm-service.