### PR TITLE
Pull in qubes-core-agent-network-manager when installing NetworkManager

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -344,6 +344,7 @@ Requires:   NetworkManager >= 0.8.1-1
 Requires:   glib2
 Requires:   polkit
 Requires:   qubes-core-agent-networking = %{version}
+Requires:   (qubes-core-agent-network-manager if NetworkManager)
 Conflicts:  qubes-core-vm < 4.0.0
 %if 0%{?is_opensuse}
 # for directory ownership


### PR DESCRIPTION
The documentation says to install qubes-core-agent-network-manager, but the system can just do it for the user by pulling it in via an RPM rich dependency.

Fixes: QubesOS/qubes-issues#9664