### PR TITLE
Support ptyxis in qubes-run-terminal

### DIFF
--- a/app-menu/qubes-run-terminal
+++ b/app-menu/qubes-run-terminal
@@ -15,6 +15,10 @@ if is_command gnome-terminal; then
     exec qubes-run-gnome-terminal
 fi
 
+if is_command ptyxis; then
+    exec ptyxis
+fi
+
 if is_command kgx; then
     exec qubes-run-gnome-console
 fi


### PR DESCRIPTION
Fedora 41 defaults to using ptyxis as its terminal instead of gnome-terminal. It also works correctly in dispVMs without needing any special --wait handling.