### PR TITLE
Fix qvm-copy behavior with symlinks

### DIFF
--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -97,6 +97,7 @@ fi
 SOURCE="${@%/}"
 
 if FILECOPY_TOTAL_BYTES=$("$scriptdir/qubes/qubes-fs-tree-check" \
+    ${ignore_symlinks+--ignore-symlinks} \
     --allow-symlinks --allow-directories --machine -- "${SOURCE}"); then
     service=qubes.Filecopy
 else

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -94,11 +94,11 @@ else
 fi
 
 # strip trailing slash from source directory
-SOURCE="${@%/}"
+SOURCE=( "${@%/}" )
 
 if FILECOPY_TOTAL_BYTES=$("$scriptdir/qubes/qubes-fs-tree-check" \
     ${ignore_symlinks} \
-    --allow-symlinks --allow-directories --machine -- "${SOURCE}"); then
+    --allow-symlinks --allow-directories --machine -- "${SOURCE[@]}"); then
     service=qubes.Filecopy
 else
     status=$?
@@ -108,8 +108,8 @@ fi
 if [[ "$PROGRESS_TYPE" = 'console' ]]; then export FILECOPY_TOTAL_BYTES; fi
 
 "$scriptdir/qubes/qrexec-client-vm" --filter-escape-chars-stderr -- "$VM" \
-    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks} -- "${SOURCE}"
+    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks} -- "${SOURCE[@]}"
 
 if [ "$OPERATION_TYPE" = "move" ] ; then
-    rm -rf -- "${SOURCE}"
+    rm -rf -- "${SOURCE[@]}"
 fi

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -93,8 +93,11 @@ else
   VM="@default"
 fi
 
+# strip trailing slash from source directory
+SOURCE="${@%/}"
+
 if FILECOPY_TOTAL_BYTES=$("$scriptdir/qubes/qubes-fs-tree-check" \
-    --allow-symlinks --allow-directories --machine -- "$@"); then
+    --allow-symlinks --allow-directories --machine -- "${SOURCE}"); then
     service=qubes.Filecopy
 else
     status=$?
@@ -104,8 +107,8 @@ fi
 if [[ "$PROGRESS_TYPE" = 'console' ]]; then export FILECOPY_TOTAL_BYTES; fi
 
 "$scriptdir/qubes/qrexec-client-vm" --filter-escape-chars-stderr -- "$VM" \
-    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks+--ignore-symlinks} -- "$@"
+    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks+--ignore-symlinks} -- "${SOURCE}"
 
 if [ "$OPERATION_TYPE" = "move" ] ; then
-    rm -rf -- "$@"
+    rm -rf -- "${SOURCE}"
 fi

--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -75,7 +75,7 @@ while [ "$#" -gt 0 ]; do
     case $1 in
         (--without-progress) export PROGRESS_TYPE=none; shift;;
         (--with-progress) export PROGRESS_TYPE=console; shift;;
-        (--ignore-symlinks) ignore_symlinks=true; shift;;
+        (--ignore-symlinks) ignore_symlinks="--ignore-symlinks"; shift;;
         (--no-ignore-symlinks) unset ignore_symlinks; shift;;
         (-h|--help) usage 0;;
         (--) shift; break;;
@@ -97,7 +97,7 @@ fi
 SOURCE="${@%/}"
 
 if FILECOPY_TOTAL_BYTES=$("$scriptdir/qubes/qubes-fs-tree-check" \
-    ${ignore_symlinks+--ignore-symlinks} \
+    ${ignore_symlinks} \
     --allow-symlinks --allow-directories --machine -- "${SOURCE}"); then
     service=qubes.Filecopy
 else
@@ -108,7 +108,7 @@ fi
 if [[ "$PROGRESS_TYPE" = 'console' ]]; then export FILECOPY_TOTAL_BYTES; fi
 
 "$scriptdir/qubes/qrexec-client-vm" --filter-escape-chars-stderr -- "$VM" \
-    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks+--ignore-symlinks} -- "${SOURCE}"
+    "$service" "$scriptdir/qubes/qfile-agent" ${ignore_symlinks} -- "${SOURCE}"
 
 if [ "$OPERATION_TYPE" = "move" ] ; then
     rm -rf -- "${SOURCE}"


### PR DESCRIPTION
Previously, `qvm-copy` had a couple of issues with symlinks:

1. A trailing slash on the source could cause errors:

````
$ qvm-copy-to-vm untrusted dir/
qubes-fs-tree-check: Refusing to copy unsafe symbolic link "dir//my-symlink"
````

but `qvm-copy-to-vm untrusted dir` worked fine.

2. `qvm-copy --ignore-symlinks` could still throw `qubes-fs-tree-check: Refusing to copy unsafe symbolic link` . If we are ignoring symlinks, `qubes-fs-tree-check` should not check for them.

## Notes

Running `qubes-fs-tree-check --ignore-symlinks --allow-symlinks` does not seem to cause an issue.