### PR TITLE
Memory query RPC service

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -15,6 +15,7 @@ etc/qubes-rpc/qubes.DetachPciDevice
 etc/qubes-rpc/qubes.Filecopy
 etc/qubes-rpc/qubes.GetAppmenus
 etc/qubes-rpc/qubes.GetImageRGBA
+etc/qubes-rpc/qubes.GetMem
 etc/qubes-rpc/qubes.InstallUpdatesGUI
 etc/qubes-rpc/qubes.OpenInVM
 etc/qubes-rpc/qubes.OpenURL

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -86,6 +86,7 @@ install:
 		qubes.StartApp \
 		qubes.PostInstall \
 		qubes.GetDate \
+		qubes.GetMem \
 		qubes.ShowInTerminal \
 		qubes.TemplateSearch \
 		qubes.TemplateDownload

--- a/qubes-rpc/qubes.GetMem
+++ b/qubes-rpc/qubes.GetMem
@@ -1,0 +1,9 @@
+#!/bin/sh
+# Return percentage of available memory.
+set -eu
+awk -- '
+  BEGIN {total=0; available=0}
+  /MemTotal/ {total=$2}
+  /MemAvailable/ {available=$2}
+  END {printf "%.0f", (available/total)*100}
+  ' /proc/meminfo

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -897,6 +897,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes-rpc/qubes.Filecopy
 %config(noreplace) /etc/qubes-rpc/qubes.OpenInVM
 %config(noreplace) /etc/qubes-rpc/qubes.OpenURL
+%config(noreplace) /etc/qubes-rpc/qubes.GetMem
 %config(noreplace) /etc/qubes-rpc/qubes.GetAppmenus
 %config(noreplace) /etc/qubes-rpc/qubes.ConnectTCP
 %config(noreplace) /etc/qubes-rpc/qubes.VMShell


### PR DESCRIPTION
What I don't like about the script: it infinitely waits for a running qube to respond for the `qubes.VMShell` service call, which I don't know how to indirectly timeout the subprocess created by `run_service_for_stdio`.

Also the table formatting is "OKayish".

Just the  bare minium info qui-domains format, not enough info to justify command-line options and it is not as great as xentop, but more useful for Qubes.

I assume the Qubes license is GPL-2.0-only, not `or-later` because I didn't find this info.