### PR TITLE
qubes-firewall: Suppress extraneous conntrack output

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -183,8 +183,8 @@ class FirewallWorker(object):
     def conntrack_drop(self, src, con):
         subprocess.run(['conntrack', '-D', '--src', src, '--dst', con[1],
                         '--proto', con[0], '--dport', con[2]],
-                       stdout=subprocess.PIPE,
-                       stderr=subprocess.STDOUT)
+                       stdout=subprocess.DEVNULL,
+                       stderr=subprocess.DEVNULL)
 
     def conntrack_get_connections(self, family, source):
         connections = set()
@@ -192,7 +192,7 @@ class FirewallWorker(object):
         with subprocess.Popen(['conntrack', '-L',
                                '--family', f'ipv{family}', '--src', source],
                              stdout=subprocess.PIPE,
-                             stderr=subprocess.STDOUT) as p:
+                             stderr=subprocess.DEVNULL) as p:
             while True:
                 line = p.stdout.readline()
                 if not line:


### PR DESCRIPTION
conntrack generally prints a status message to stderr before exiting, which interferes with listing connections. Output from dropping connections was unused.

Testing: developed within my `sys-firewall`, verified that `conntrack_get_connections` no longer observes lines containing "conntrack", and that connection dropping still works.

Fixes QubesOS/qubes-issues#9760