### PR TITLE
Disable systemd-nsresourced and systemd-userdbd for minimal sys-net and minimal sys-usb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ endif
 SYSTEM_DROPINS += polkit.service
 SYSTEM_DROPINS += abrtd.service
 SYSTEM_DROPINS += bluetooth.service
+SYSTEM_DROPINS += systemd-nsresourced.service
+SYSTEM_DROPINS += systemd-nsresourced.socket
+SYSTEM_DROPINS += systemd-userdbd.service
+SYSTEM_DROPINS += systemd-userdbd.socket
 
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -109,6 +109,10 @@ lib/systemd/system/tor@default.service.d/30_qubes.conf
 lib/systemd/system/sysinit.target.d/30_qubes.conf
 lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
+lib/systemd/system/systemd-nsresourced.service.d/30_qubes.conf
+lib/systemd/system/systemd-nsresourced.socket.d/30_qubes.conf
+lib/systemd/system/systemd-userdbd.service.d/30_qubes.conf
+lib/systemd/system/systemd-userdbd.socket.d/30_qubes.conf
 lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
 usr/lib/sysctl.d/20-qubes-core.conf
 usr/lib/systemd/user/tracker-extract-3.service.d/30_qubes.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1310,6 +1310,10 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/tmp.mount.d/30_qubes.conf
 %dir %_unitdir/sysinit.target.d
 %_unitdir/sysinit.target.d/30_qubes.conf
+%_unitdir/systemd-nsresourced.service.d/30_qubes.conf
+%_unitdir/systemd-nsresourced.socket.d/30_qubes.conf
+%_unitdir/systemd-userdbd.service.d/30_qubes.conf
+%_unitdir/systemd-userdbd.socket.d/30_qubes.conf
 %dir %_userunitdir/*.service.d
 %_userunitdir/tracker-extract-3.service.d/30_qubes.conf
 %_userunitdir/tracker-miner-fs-3.service.d/30_qubes.conf

--- a/vm-systemd/systemd-nsresourced.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-nsresourced.service.d/30_qubes.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Needs to be started as it creates /var/run/qubes-service/* files
+After=qubes-sysinit.service
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/systemd-nsresourced.socket.d/30_qubes.conf
+++ b/vm-systemd/systemd-nsresourced.socket.d/30_qubes.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Needs to be started as it creates /var/run/qubes-service/* files
+After=qubes-sysinit.service
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/systemd-userdbd.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-userdbd.service.d/30_qubes.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Needs to be started as it creates /var/run/qubes-service/* files
+After=qubes-sysinit.service
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/systemd-userdbd.socket.d/30_qubes.conf
+++ b/vm-systemd/systemd-userdbd.socket.d/30_qubes.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Needs to be started as it creates /var/run/qubes-service/* files
+After=qubes-sysinit.service
+ConditionPathExists=!/var/run/qubes-service/minimal-netvm
+ConditionPathExists=!/var/run/qubes-service/minimal-usbvm


### PR DESCRIPTION
This disables two more services for minimal sys-net and minimal sys-usb (see https://github.com/QubesOS/qubes-core-agent-linux/pull/540)  :
  * ``systemd-nsresourced.service`` and its socket ``systemd-nsresourced.socket``
  * ``systemd-userdbd.service`` and its socket ``systemd-userdbd.socket``