### PR TITLE
fix(qubes-download-dom0-updates): manually specify vars dir in args

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -13,6 +13,8 @@ elif [ -f "$DOM0_UPDATES_DIR/etc/yum.conf" ]; then
 fi
 # DNF uses /etc/yum.repos.d, even when --installroot is specified
 OPTS+=("--setopt=reposdir=$DOM0_UPDATES_DIR/etc/yum.repos.d")
+# DNF does not find the right vars dir automatically when --installroot is used
+OPTS+=("--setopt=varsdir=$DOM0_UPDATES_DIR/etc/yum/vars")
 CLEAN_OPTS=("${OPTS[@]}")
 # DNF verifies signatures implicitly, but yumdownloader does not.
 SIGNATURE_REGEX=""


### PR DESCRIPTION
This fixes custom vars for DNF on updatevms running Fedora 41. 

Even though the custom variables are copied over [here](https://github.com/QubesOS/qubes-core-admin-linux/blob/main/dom0-updates/qubes-dom0-update#L305C37-L305C49), `dnf` only replaces them with the added args in this patch on Fedora versions > 40.