### PR TITLE
Changes related to F42 update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,8 +59,6 @@ SYSTEM_DROPINS += abrtd.service
 SYSTEM_DROPINS += bluetooth.service
 SYSTEM_DROPINS += systemd-nsresourced.service
 SYSTEM_DROPINS += systemd-nsresourced.socket
-SYSTEM_DROPINS += systemd-userdbd.service
-SYSTEM_DROPINS += systemd-userdbd.socket
 
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -112,8 +112,6 @@ lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 lib/systemd/system/systemd-nsresourced.service.d/30_qubes.conf
 lib/systemd/system/systemd-nsresourced.socket.d/30_qubes.conf
-lib/systemd/system/systemd-userdbd.service.d/30_qubes.conf
-lib/systemd/system/systemd-userdbd.socket.d/30_qubes.conf
 lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
 lib/systemd/system/home.mount
 lib/systemd/system/usr-local.mount

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1312,8 +1312,6 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/sysinit.target.d/30_qubes.conf
 %_unitdir/systemd-nsresourced.service.d/30_qubes.conf
 %_unitdir/systemd-nsresourced.socket.d/30_qubes.conf
-%_unitdir/systemd-userdbd.service.d/30_qubes.conf
-%_unitdir/systemd-userdbd.socket.d/30_qubes.conf
 %dir %_userunitdir/*.service.d
 %_userunitdir/tracker-extract-3.service.d/30_qubes.conf
 %_userunitdir/tracker-miner-fs-3.service.d/30_qubes.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -431,10 +431,7 @@ a VM with SELinux enforcing, as is the default on Red Hat-family distributions.
 
 %postun selinux
 if [ "$1" -eq 0 ]; then
-    %selinux_modules_uninstall \
-        %{_datadir}/selinux/packages/qubes-qfile-unpacker.pp \
-        %{_datadir}/selinux/packages/qubes-xendriverdomain.pp \
-        %{_datadir}/selinux/packages/qubes-misc.pp
+    %selinux_modules_uninstall %{_datadir}/selinux/packages/qubes-qfile-unpacker.pp %{_datadir}/selinux/packages/qubes-xendriverdomain.pp %{_datadir}/selinux/packages/qubes-misc.pp
 fi || :
 
 %pre selinux

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -57,6 +57,8 @@ disable upower.service
 disable colord.service
 disable wpa_supplicant@.service
 disable dkms.service
+disable systemd-userdbd.service
+disable systemd-userdbd.socket
 enable qubes-relabel-root.service
 enable qubes-relabel-rw.service
 

--- a/vm-systemd/systemd-userdbd.service.d/30_qubes.conf
+++ b/vm-systemd/systemd-userdbd.service.d/30_qubes.conf
@@ -1,5 +1,0 @@
-[Unit]
-# Needs to be started as it creates /var/run/qubes-service/* files
-After=qubes-sysinit.service
-ConditionPathExists=!/var/run/qubes-service/minimal-netvm
-ConditionPathExists=!/var/run/qubes-service/minimal-usbvm

--- a/vm-systemd/systemd-userdbd.socket.d/30_qubes.conf
+++ b/vm-systemd/systemd-userdbd.socket.d/30_qubes.conf
@@ -1,5 +1,0 @@
-[Unit]
-# Needs to be started as it creates /var/run/qubes-service/* files
-After=qubes-sysinit.service
-ConditionPathExists=!/var/run/qubes-service/minimal-netvm
-ConditionPathExists=!/var/run/qubes-service/minimal-usbvm


### PR DESCRIPTION
Disable systemd-userdbd as it causes issues on upgrade, and isn't relevant to
qubes.
And also fix SELinux %post install macro usage.

QubesOS/qubes-issues#9807