### PR TITLE
Agent firewall long hostname crash

### DIFF
--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -176,7 +176,7 @@ class FirewallWorker(object):
                         ' due to qubesdb path length limit').format(
                             host, source))
                     self.log.error('See https://github.com/QubesOS/'
-                        'qubes-issues/9085')
+                        'qubes-issues/issues/9084')
                 else:
                     raise
 

--- a/qubesagent/firewall.py
+++ b/qubesagent/firewall.py
@@ -167,7 +167,18 @@ class FirewallWorker(object):
         self.qdb.rm('/dns/{}/'.format(source))
 
         for host, hostaddrs in dns.items():
-            self.qdb.write('/dns/{}/{}'.format(source, host), str(hostaddrs))
+            path = '/dns/{}/{}'.format(source, host)
+            try:
+                self.qdb.write(path, str(hostaddrs))
+            except Exception as err:
+                if len(path) > 64 and err.args == (0, 'Error'):
+                    self.log.error(('Unable to add DNS information for {} ({})'
+                        ' due to qubesdb path length limit').format(
+                            host, source))
+                    self.log.error('See https://github.com/QubesOS/'
+                        'qubes-issues/9085')
+                else:
+                    raise
 
     def update_handled(self, addr):
         """

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -40,6 +40,8 @@ class DummyQubesDB(object):
             self.entries.pop(path)
 
     def write(self, path, val):
+        if len(path) > 64:
+            raise DummyQubesDBError(0, 'Error')
         self.entries[path] = val
 
     def multiread(self, prefix):
@@ -65,6 +67,8 @@ class DummyQubesDB(object):
         except IndexError:
             return None
 
+class DummyQubesDBError(Exception):
+    "Raised by QubesDB"
 
 class FirewallWorker(qubesagent.firewall.FirewallWorker):
     def __init__(self):
@@ -158,6 +162,35 @@ class WorkerCommon(object):
         self.assertIsNotNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
         self.obj.apply_rules('10.137.0.1', [{'action': 'drop'}])
         self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
+
+    def test_701_dns_info(self):
+        self.obj.conntrack_get_connections = Mock(return_value=[])
+        rules = [
+            {'action': 'accept', 'proto': 'tcp',
+                'dstports': '80-80', 'dsthost': 'ripe.net'},
+            {'action': 'drop'},
+        ]
+        self.obj.apply_rules('10.137.0.1', rules)
+        self.assertIsNotNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
+        self.obj.apply_rules('10.137.0.1', [{'action': 'drop'}])
+        self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
+
+    def test_702_dns_info_qubesdb_path_length_crash(self):
+        self.obj.conntrack_get_connections = Mock(return_value=[])
+        rules = [
+            {'action': 'accept', 'proto': 'tcp',
+                'dstports': '443-443', 'dsthost': 'www.google.com'},
+            {'action': 'accept', 'proto': 'tcp',
+                'dstports': '443-443', 'dsthost': 'prod-dynamite-prod-05-us-signaler-pa.clients6.google.com'},
+            {'action': 'drop'},
+        ]
+        self.obj.apply_rules('10.137.0.22', rules)
+        self.assertIsNotNone(self.obj.qdb.read('/dns/10.137.0.22/www.google.com'))
+        # Unfortunately, this is assertIsNone until the QubesDB path length limit is raised.
+        self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.22/prod-dynamite-prod-05-us-signaler-pa.clients6.google.com'))
+        self.obj.apply_rules('10.137.0.22', [{'action': 'drop'}])
+        self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.22/www.google.com'))
+        self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.22/prod-dynamite-prod-05-us-signaler-pa.clients6.google.com'))
 
 class TestNftablesWorker(TestCase, WorkerCommon):
     def setUp(self):

--- a/qubesagent/test_firewall.py
+++ b/qubesagent/test_firewall.py
@@ -163,18 +163,6 @@ class WorkerCommon(object):
         self.obj.apply_rules('10.137.0.1', [{'action': 'drop'}])
         self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
 
-    def test_701_dns_info(self):
-        self.obj.conntrack_get_connections = Mock(return_value=[])
-        rules = [
-            {'action': 'accept', 'proto': 'tcp',
-                'dstports': '80-80', 'dsthost': 'ripe.net'},
-            {'action': 'drop'},
-        ]
-        self.obj.apply_rules('10.137.0.1', rules)
-        self.assertIsNotNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
-        self.obj.apply_rules('10.137.0.1', [{'action': 'drop'}])
-        self.assertIsNone(self.obj.qdb.read('/dns/10.137.0.1/ripe.net'))
-
     def test_702_dns_info_qubesdb_path_length_crash(self):
         self.obj.conntrack_get_connections = Mock(return_value=[])
         rules = [


### PR DESCRIPTION
Long hostnames result in qubesdb paths that exceed the current 64 character limit.  Instead of crashing the firewall daemon, log the error and continue without adding the hostname to the DNS records.

This is a workaround, not a fix, for https://github.com/QubesOS/qubes-issues/issues/9084.  The fix requires either longer path support in qubesdb or using a different schema so that keys will not exceed the qubesdb path length limit.