### PR TITLE
qubes-core-agent: add tar to dependencies

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -136,6 +136,8 @@ Requires:   e2fsprogs
 Requires:   hostname
 # for Qubes Manager VM updater
 Requires:   xterm
+# for qubes-core-admin-linux vmupdate
+Requires:   tar
 # for qubes-desktop-run
 %if 0%{?is_opensuse}
 Requires:   python%{python3_pkgversion}-gobject


### PR DESCRIPTION
New template updater (core-admin-linux vmupdate) uses tar for extracting update agent files.
But currently tar is not dependency of Qubes core components, so people maybe remove it mistakenly.
Adding tar to core-agent dependencies will reduces such risks.