### PR TITLE
Assure `script` is installed for dom0 update

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -306,6 +306,9 @@ Requires:   fakeroot
 Conflicts:  qubes-core-vm < 4.0.0
 Requires:   tar
 Requires:   qubes-repo-templates
+%if 0%{?fedora} >= 42
+Requires:   util-linux-script
+%endif
 
 %description dom0-updates
 Scripts required to handle dom0 updates.


### PR DESCRIPTION
On Fedora 42, `script` executable is moved to `util-linux-script` package. It is required for `qubes-download-dom0-update.sh` to work.