### PR TITLE
Launch `volumeicon` and `pasystray` only for audiovm

### DIFF
--- a/autostart-dropins/pasystray.desktop
+++ b/autostart-dropins/pasystray.desktop
@@ -1,0 +1,3 @@
+[Desktop Entry]
+Exec=/usr/lib/qubes/qvm-service-wrapper audiovm pasystray
+

--- a/autostart-dropins/volumeicon.desktop
+++ b/autostart-dropins/volumeicon.desktop
@@ -1,0 +1,3 @@
+[Desktop Entry]
+Exec=/usr/lib/qubes/qvm-service-wrapper audiovm volumeicon
+


### PR DESCRIPTION
fixes: https://github.com/QubesOS/qubes-issues/issues/9158