### PR TITLE
Avoid de-configuring non-existing interface

### DIFF
--- a/network/vif-route-qubes
+++ b/network/vif-route-qubes
@@ -144,7 +144,9 @@ table inet qubes-nat-accel {
         fi
         ;;
     offline)
-        do_without_error ifdown "${vif}"
+        if [ -e /sys/class/net/"$vif" ]; then
+            do_without_error ifdown "${vif}"
+        fi
         ipcmd='del'
         nftables_cmd=delete
         cmdprefix='do_without_error'
@@ -240,14 +242,20 @@ if [ "${ip}" ]; then
             log error "Cannot set IPv6 route to ${addr}, IPv6 disabled in the kernel"
             continue
         fi
-        ${cmdprefix} ip route "${ipcmd}" "${addr}" dev "${vif}" metric "$metric"
+        if [ "$ipcmd" = "add" ] || [ -e /sys/class/net/"$vif" ]; then
+            ${cmdprefix} ip route "${ipcmd}" "${addr}" dev "${vif}" metric "$metric"
+        fi
 
         network_hooks "${command}" "${vif}" "${addr}"
     done
-    ${cmdprefix} ip addr "${ipcmd}" "${back_ip}/32" dev "${vif}"
+    if [ "$ipcmd" = "add" ] || [ -e /sys/class/net/"$vif" ]; then
+        ${cmdprefix} ip addr "${ipcmd}" "${back_ip}/32" dev "${vif}"
+    fi
     if [[ -n "${back_ip6}" ]] && [[ "${back_ip6}" != "fe80:"* ]] && [[ "$ipv6_disabled" = '0' ]]; then
-        ${cmdprefix} ip addr "${ipcmd}" "${back_ip6}/128" dev "${vif}"
-        echo 1 >"/proc/sys/net/ipv6/conf/${vif}/proxy_ndp"
+        if [ "$ipcmd" = "add" ] || [ -e /sys/class/net/"$vif" ]; then
+            ${cmdprefix} ip addr "${ipcmd}" "${back_ip6}/128" dev "${vif}"
+            echo 1 >"/proc/sys/net/ipv6/conf/${vif}/proxy_ndp"
+        fi
     fi
 else
     network_hooks "${command}" "${vif}"


### PR DESCRIPTION
When 'vif-route-qubes offline' is called, the interface (usually)
doesn't exist anymore. In that case, commands are called with
'do_without_error', but while it doesn't fail the script, it still logs
misleading error message.

Avoid calling 'ip' on non-existing interface to remove its
address/route, as those are removed by the kernel implicitly anyway.
But still call them on online action (if interface doesn't exist at this
point, it will fail, and that's intentional to get proper error
message), or when the interface still exist at the time the script is
called (in which case, it may still race against disappearing the
interface, but then there is 'do_without_error' prefix as the
last resort). This way, it avoids confusing error in the common case,
but still ensure things are cleaned up in the unusual case of interface
staying there.