### PR TITLE
rpm: require python3-libdnf5 on F41+

### DIFF
--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -171,6 +171,7 @@ Requires:   dbus-tools
 %endif
 %if 0%{?fedora} >= 41
 Requires:   libdnf5-plugin-actions
+Requires:   python3-libdnf5
 %else
 %if 0%{?rhel} == 8
 # we need to stick to related DNF python version


### PR DESCRIPTION
It's required for the qubes-vm-update tool to report progress of the
update.

QubesOS/qubes-issues#9244
Related to https://github.com/QubesOS/qubes-core-admin-linux/pull/187