### PR TITLE
Free some memory on resume before re-loading modules

### DIFF
--- a/qubes-rpc/prepare-suspend
+++ b/qubes-rpc/prepare-suspend
@@ -81,6 +81,12 @@ if [ "$action" = "suspend" ]; then
     done
     echo "$LOADED_MODULES" > /var/run/qubes-suspend-modules-loaded
 else
+    # Force some apps into swap, to free memory for wifi drivers to be loaded
+    # in a moment. Some of those allocations cannot trigger swappin on their
+    # own. It's ok for this command to use more memory than VM has RAM. But it
+    # cannot exceed swap size.
+    dd if=/dev/zero of=/dev/null bs=512M count=1 status=none
+    echo 1 > /proc/sys/vm/compact_memory
     # Free some RAM for minimal netvm to prevent memory issues when loading
     # drivers
     if [ -f /var/run/qubes-service/minimal-netvm ]; then


### PR DESCRIPTION
Intel wifi driver wants to allocate large contiguous memory blocks
(for example with Intel BE200 it's 128k). Try to force some memory
(possibly pushing some apps into swap) and then force memory compaction
- just before loading wifi drivers back (depending on device, module
either gets loaded, or just bound to the device).

Do this by using dd to allocate 512MB of memory. The amount is large
enough to force swapping, but it's still significantly below the swap
size (1GB) so it doesn't trigger OOM.

Fixes QubesOS/qubes-issues#9869