### PR TITLE
Simplify logging apt-get update output

### DIFF
--- a/package-managers/upgrades-installed-check
+++ b/package-managers/upgrades-installed-check
@@ -32,8 +32,7 @@ elif [ -e /etc/debian_version ]; then
     set -e
     set -o pipefail
     if ! $skip_refresh; then
-        # shellcheck disable=SC2034
-        apt_get_update_output="$(apt-get -q update 2>&1 | tee /proc/self/fd/2)"
+        apt-get -q update >&2
     fi
     apt_get_upgrade_output="$(LANG="C" apt-get -s upgrade 2>&1)"
     exit_code="$?"


### PR DESCRIPTION
The 'apt_get_update_output' variable is unused, so avoid complexity with
saving apt-get update output and printing it at the same time. This
fixes checking updates on Debian, as 'tee /proc/self/fd/2' fails when
the script is called from systemd service (via systemd timer).

Fixes QubesOS/qubes-issues#9895