### PR TITLE
SSL auth and user GPG key support for user templates repos

### DIFF
--- a/qubes-rpc/qvm-template-repo-query
+++ b/qubes-rpc/qvm-template-repo-query
@@ -26,6 +26,25 @@ repodir=$(mktemp -d)
 trap 'rm -r "$repodir"' EXIT
 cat > "$repodir/template.repo"
 
+# extract keys from wrapper in repo file
+mkdir "$repodir/keys"
+sed -i "s~/etc/qubes/repo-templates/keys/~$repodir/keys/~" "$repodir/template.repo"
+in_wrapper=false
+line_is_filename=true
+while read -r line; do
+    [[ "$line" == "###!Q!BEGIN-QUBES-WRAPPER!Q!###" ]] && in_wrapper=true && continue
+    [[ "$line" == "###!Q!END-QUBES-WRAPPER!Q!###" ]] && in_wrapper=false && continue
+    $in_wrapper || continue
+    if $line_is_filename; then
+        filename="${line:1}"
+        line_is_filename=false
+    else
+        mkdir -p "$(dirname "$filename")"
+        echo "${line:1}" | base64 -d > "$filename"
+        line_is_filename=true
+    fi
+done < "$repodir/template.repo"
+
 DNF5=false
 if [ "$(readlink /usr/bin/dnf)" = "dnf5" ]; then
     DNF5=true


### PR DESCRIPTION
This PR adds a wrapper in the payload sent for qubes.TemplateSearch and qubes.TemplateDownload RPC calls. This wrapper allows files to be sent to the Proxy VM that would be used by DNF .

To prevent conflict and permission issues, the files are not written in ``/etc/qubes/repo-templates/`` but in the temporary directory where the transmitted repository file is stored. Then, this repository file is patched in order to modify the path of the transmitted files.

https://github.com/QubesOS/qubes-issues/issues/9850