### PR TITLE
Wait for session only if necessary

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -37,6 +37,7 @@ etc/qubes-rpc/qubes.VMRootShell
 etc/qubes-rpc/qubes.VMExec
 etc/qubes-rpc/qubes.VMExecGUI
 etc/qubes-rpc/qubes.WaitForSession
+etc/qubes-rpc/qubes.WaitForRunningSystem
 etc/qubes-rpc/qubes.GetDate
 etc/qubes-suspend-module-blacklist
 etc/qubes/autostart/*

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -77,6 +77,7 @@ install:
 		qubes.SuspendPreAll \
 		qubes.SuspendPostAll \
 		qubes.WaitForSession \
+		qubes.WaitForRunningSystem \
 		qubes.DetachPciDevice \
 		qubes.Backup qubes.Restore \
 		qubes.RegisterBackupLocation \

--- a/qubes-rpc/qubes.WaitForRunningSystem
+++ b/qubes-rpc/qubes.WaitForRunningSystem
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+systemctl --wait --quiet is-system-running
+exit 0

--- a/qubes-rpc/qubes.WaitForSession
+++ b/qubes-rpc/qubes.WaitForSession
@@ -1,11 +1,12 @@
 #!/bin/sh
+set -eu
 
-USERNAME="$(qubesdb-read /default-user || echo 'user')"
-
-while ! [ -e "/var/run/qubes/qrexec-server.$USERNAME.sock" ]
-do
-    sleep 0.1
-done
+if test "$(qubesdb-read /qubes-gui-enabled)" = "True"; then
+    user="$(qubesdb-read /default-user || echo 'user')"
+    while ! [ -e "/var/run/qubes/qrexec-server.$user.sock" ]; do
+        sleep 0.1
+    done
+fi
 
 systemctl --user --wait --quiet is-system-running
 

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -917,6 +917,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes-rpc/qubes.SuspendPost
 %config(noreplace) /etc/qubes-rpc/qubes.SuspendPostAll
 %config(noreplace) /etc/qubes-rpc/qubes.WaitForSession
+%config(noreplace) /etc/qubes-rpc/qubes.WaitForRunningSystem
 %config(noreplace) /etc/qubes-rpc/qubes.DetachPciDevice
 %config(noreplace) /etc/qubes-rpc/qubes.Backup
 %config(noreplace) /etc/qubes-rpc/qubes.Restore


### PR DESCRIPTION
The 'gui' feature is not passed via QubesDB to the qube, if it was, only one service would be necessary.

For: https://github.com/QubesOS/qubes-issues/issues/1512

---

This makes the handler for `domain-start` simpler, besides not having to sleep if there is no GUI for a qube.