### PR TITLE
Disable (in updatevm) dnf ANSI coloring of output

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -74,6 +74,7 @@ if type dnf >/dev/null 2>&1; then
     CLEAN_OPTS+=(--noplugins -y)
     "$UPDATE_CMD" "${OPTS[@]}" "$UPDATE_ACTION" --help | grep -q best && UPDATE_ARGUMENTS+=(--best)
     "$UPDATE_CMD" "${OPTS[@]}" "$UPDATE_ACTION" --help | grep -q allowerasing && UPDATE_ARGUMENTS+=(--allowerasing)
+    "$UPDATE_CMD" "${OPTS[@]}" "$UPDATE_ACTION" --help | grep -q color && UPDATE_ARGUMENTS+=(--color=never)
     if "$UPDATE_CMD" --version | grep -q dnf5 && [ "$CHECK_ONLY" = "1" ]; then
         UPDATE_ACTION=check-upgrade
     fi


### PR DESCRIPTION
Since dnf5 does a lot of coloring of output, it is better to disable it for UpdateVM as it messes the outputs of many actions such as: `qubes-dom0-update --action=search|list|...`

improves: https://github.com/QubesOS/qubes-issues/issues/9482