### PR TITLE
archlinux: Sync /etc/fstab with other distros

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -100,6 +100,14 @@ package_qubes-vm-core() {
     make -C qubes-rpc/kde DESTDIR="$pkgdir" install
     make -C qubes-rpc/nautilus DESTDIR="$pkgdir" install
     make -C qubes-rpc/thunar DESTDIR="$pkgdir" install
+    make -C filesystem DESTDIR="$pkgdir" install
+
+    # Adjust fstab for Arch
+    mv "$pkgdir/etc/fstab" "$pkgdir/etc/fstab.qubes"
+    echo "
+# This MUST be a ramfs, not a tmpfs!  The data here is incredibly sensitive
+# (allows root access) and must not be leaked to disk.
+tmpfs                   /etc/pacman.d/gnupg/private-keys-v1.d       ramfs   defaults,noexec,nosuid,nodev,mode=600    0 0" >> "$pkgdir/etc/fstab.qubes"
 
     # Install systemd script allowing to automount /lib/modules
     install -m 644 "archlinux/PKGBUILD.qubes-ensure-lib-modules.service" "${pkgdir}/usr/lib/systemd/system/qubes-ensure-lib-modules.service"

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -34,9 +34,6 @@ pre_install() {
         cp /etc/fstab /var/lib/qubes/fstab.orig
     fi
 
-    # Add qubes core related fstab entries
-    echo "xen	/proc/xen	xenfs	defaults	0 0" >> /etc/fstab
-
     usermod -L root
     usermod -L user
 }

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -90,6 +90,15 @@ update_qubesconfig() {
         cp -f /etc/fstab.qubes /etc/fstab
     fi
 
+    # Fix fstab update to core-agent-linux 4.3.19
+    if grep -q '/rw/home\|/rw/usrlocal' /etc/fstab; then
+        sed -i \
+            -e '/# Template Binds/d' \
+            -e '/\/rw\/home/d' \
+            -e '/\/rw\/usrlocal/d' \
+            /etc/fstab
+    fi
+
     #/usr/lib/qubes/update-proxy-configs
     # Archlinux pacman configuration is handled in update_finalize
 

--- a/archlinux/PKGBUILD.install
+++ b/archlinux/PKGBUILD.install
@@ -85,8 +85,10 @@ update_qubesconfig() {
         mount /usr/local || :
     fi
 
-    # Fix fstab update to core-agent-linux 4.0.33
-    grep -F -q "/rw/usrlocal" /etc/fstab || sed "/\/rw\/home/a\/rw\/usrlocal    \/usr\/local  none    noauto,bind,defaults 0 0" -i /etc/fstab
+    # Install qubes version of fstab
+    if ! grep -q dmroot /etc/fstab; then
+        cp -f /etc/fstab.qubes /etc/fstab
+    fi
 
     #/usr/lib/qubes/update-proxy-configs
     # Archlinux pacman configuration is handled in update_finalize


### PR DESCRIPTION
The custom persist feature relies on /home etc not being in /etc/fstab anymore.
See commit messages for details.

Fixes QubesOS/qubes-issues#9975