### PR TITLE
Use rpc-config for running qubes.VMRoot* services as root

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -36,6 +36,7 @@ etc/qubes-rpc/qubes.VMShell
 etc/qubes-rpc/qubes.VMRootShell
 etc/qubes-rpc/qubes.VMExec
 etc/qubes-rpc/qubes.VMExecGUI
+etc/qubes-rpc/qubes.VMRootExec
 etc/qubes-rpc/qubes.WaitForSession
 etc/qubes-rpc/qubes.WaitForRunningSystem
 etc/qubes-rpc/qubes.GetDate

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -55,6 +55,8 @@ etc/qubes/rpc-config/qubes.StartApp
 etc/qubes/rpc-config/qubes.InstallUpdatesGUI
 etc/qubes/rpc-config/qubes.VMShell+WaitForSession
 etc/qubes/rpc-config/qubes.VMExecGUI
+etc/qubes/rpc-config/qubes.VMRootExec
+etc/qubes/rpc-config/qubes.VMRootShell
 etc/qubes/suspend-post.d/README
 etc/qubes/suspend-post.d/*.sh
 etc/qubes/suspend-pre.d/README

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -72,6 +72,7 @@ install:
 		qubes.Filecopy qubes.OpenInVM qubes.VMShell \
 		qubes.VMRootShell \
 		qubes.VMExec \
+		qubes.VMRootExec \
 		qubes.OpenURL \
 		qubes.SuspendPre qubes.SuspendPost qubes.GetAppmenus \
 		qubes.SuspendPreAll \

--- a/qubes-rpc/qubes.VMRootExec
+++ b/qubes-rpc/qubes.VMRootExec
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+exec /usr/bin/qubes-vmexec "$@"

--- a/qubes-rpc/qubes.VMRootExec.config
+++ b/qubes-rpc/qubes.VMRootExec.config
@@ -1,0 +1,1 @@
+force-user='root'

--- a/qubes-rpc/qubes.VMRootShell.config
+++ b/qubes-rpc/qubes.VMRootShell.config
@@ -1,0 +1,1 @@
+force-user='root'

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -911,6 +911,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes-rpc/qubes.VMShell
 %config(noreplace) /etc/qubes-rpc/qubes.VMExec
 %config(noreplace) /etc/qubes-rpc/qubes.VMExecGUI
+%config(noreplace) /etc/qubes-rpc/qubes.VMRootExec
 %config(noreplace) /etc/qubes-rpc/qubes.VMRootShell
 %config(noreplace) /etc/qubes-rpc/qubes.SuspendPre
 %config(noreplace) /etc/qubes-rpc/qubes.SuspendPreAll

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -943,6 +943,8 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes/rpc-config/qubes.InstallUpdatesGUI
 %config(noreplace) /etc/qubes/rpc-config/qubes.VMShell+WaitForSession
 %config(noreplace) /etc/qubes/rpc-config/qubes.VMExecGUI
+%config(noreplace) /etc/qubes/rpc-config/qubes.VMRootExec
+%config(noreplace) /etc/qubes/rpc-config/qubes.VMRootShell
 %config(noreplace) /etc/default/grub.qubes
 
 # MIME stuff


### PR DESCRIPTION
Don't require setting user=root in each policy line for them

Fixes QubesOS/qubes-issues#9939