### PR TITLE
qubes-core-agent: remove conflict with firewalld

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -79,7 +79,6 @@ Recommends:
     xterm
 Conflicts:
     qubes-core-agent-linux,
-    firewalld,
     qubes-core-vm-sysvinit,
     qubes-gui-agent (<< 4.1.6-1),
     pulseaudio-qubes (<< 4.2.0-1),

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -125,7 +125,6 @@ Vendor:     Invisible Things Lab
 License:    GPL
 URL:        https://www.qubes-os.org
 
-Conflicts:  firewalld
 Requires:   xdg-utils
 Requires:   qubes-utils >= 3.1.3
 Requires:   qubes-utils-libs >= 4.3.1


### PR DESCRIPTION
Currently, `qubes-core-agent` does not allow installation alongside `firewalld`. They seem to get along as fine as one would expect when allowed, though. Users should be allowed to use it if they want.