### PR TITLE
 qubes-core-agent: remove conflict with firewalld

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ SYSTEM_DROPINS += cups.service cups-browsed.service cups.path cups.socket ModemM
 SYSTEM_DROPINS += getty@tty.service serial-getty@.service
 SYSTEM_DROPINS += tmp.mount
 SYSTEM_DROPINS += org.cups.cupsd.service org.cups.cupsd.path org.cups.cupsd.socket
+SYSTEM_DROPINS += firewalld.service
 SYSTEM_DROPINS += systemd-random-seed.service
 SYSTEM_DROPINS += tor.service tor@default.service
 SYSTEM_DROPINS += systemd-timesyncd.service

--- a/debian/control
+++ b/debian/control
@@ -79,7 +79,6 @@ Recommends:
     xterm
 Conflicts:
     qubes-core-agent-linux,
-    firewalld,
     qubes-core-vm-sysvinit,
     qubes-gui-agent (<< 4.1.6-1),
     pulseaudio-qubes (<< 4.2.0-1),

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -82,6 +82,7 @@ lib/systemd/system/cups.service.d/30_qubes.conf
 lib/systemd/system/cups.socket.d/30_qubes.conf
 lib/systemd/system/cups-browsed.service.d/30_qubes.conf
 lib/systemd/system/exim4.service.d/30_qubes.conf
+lib/systemd/system/firewalld.service.d/30_qubes.conf
 lib/systemd/system/getty@tty.service.d/30_qubes.conf
 lib/systemd/system/netfilter-persistent.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.path.d/30_qubes.conf

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -125,7 +125,6 @@ Vendor:     Invisible Things Lab
 License:    GPL
 URL:        https://www.qubes-os.org
 
-Conflicts:  firewalld
 Requires:   xdg-utils
 Requires:   qubes-utils >= 3.1.3
 Requires:   qubes-utils-libs >= 4.3.1

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1298,6 +1298,7 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/org.cups.cupsd.socket.d/30_qubes.conf
 %dir %_unitdir/org.cups.cupsd.path.d
 %_unitdir/org.cups.cupsd.path.d/30_qubes.conf
+%_unitdir/firewalld.service.d/30_qubes.conf
 %_unitdir/getty@tty.service.d/30_qubes.conf
 %_unitdir/ModemManager.service.d/30_qubes.conf
 %_unitdir/NetworkManager.service.d/30_qubes.conf

--- a/vm-systemd/75-qubes-vm.preset
+++ b/vm-systemd/75-qubes-vm.preset
@@ -34,6 +34,7 @@
 disable avahi.service
 disable avahi-daemon.service
 disable avahi-daemon.socket
+disable firewalld.service
 
 # Fedora only services
 disable rpcbind.service

--- a/vm-systemd/firewalld.service.d/30_qubes.conf
+++ b/vm-systemd/firewalld.service.d/30_qubes.conf
@@ -1,0 +1,3 @@
+[Unit]
+ConditionPathExists=/var/run/qubes-service/firewalld
+After=qubes-firewall.service


### PR DESCRIPTION
Retrying #580 :crossed_fingers: 

Currently, qubes-core-agent does not allow installation alongside firewalld. They seem to get along as fine as one would expect when allowed, though. Users should be allowed to use it if they want.

firewalld will not run even if the default systemd service is enabled: The service is actually enabled by presence of `/var/run/qubes-service/firewalld`.

