### PR TITLE
Assume GUI is enabled if dom0 didn't provide that info

### DIFF
--- a/qubes-rpc/qubes.WaitForSession
+++ b/qubes-rpc/qubes.WaitForSession
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-if test "$(qubesdb-read /qubes-gui-enabled)" = "True"; then
+if test "$(qubesdb-read --default=True /qubes-gui-enabled)" = "True"; then
     user="$(qubesdb-read /default-user || echo 'user')"
     while ! [ -e "/var/run/qubes/qrexec-server.$user.sock" ]; do
         sleep 0.1


### PR DESCRIPTION
Generally we require dom0 to be updated before VM, so that qubesdb key
should always be there. But since handling the opposite case here is
easy, lets do that anyway.