### PR TITLE
arch:  fix SPDX license

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -6,7 +6,7 @@ pkgrel=@REL@
 pkgdesc="The Qubes core files for installation inside a Qubes VM."
 arch=("x86_64")
 url="https://qubes-os.org/"
-license=('GPL')
+license=('GPL-2.0-or-later')
 makedepends=(
     gcc
     make


### PR DESCRIPTION
The arch build logs errors regarding the `license` not being a recognized SPDX identifier. This changes it from `GPL` to `GPL-2.0-or-later`. Cleans up build logs.