### PR TITLE
arch: break out qubes-vm-nautilus from qubes-vm-core

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -208,7 +208,7 @@ package_qubes-vm-keyring() {
 
 package_qubes-vm-nautilus() {
     pkgdesc="Qubes OS Nautilus addons for inter-VM file copy/move/open"
-    conflicts=('qubes-vm-core<4.3.20')
+    conflicts=('qubes-vm-core<4.3.26')
     depends=(
         bash
         python-gobject

--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -1,6 +1,6 @@
 # Maintainer: Frédéric Pierret (fepitre) <frederic@invisiblethingslab.com>
 
-pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring qubes-vm-passwordless-root qubes-vm-dom0-updates)
+pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring qubes-vm-nautilus qubes-vm-passwordless-root qubes-vm-dom0-updates)
 pkgver=@VERSION@
 pkgrel=@REL@
 pkgdesc="The Qubes core files for installation inside a Qubes VM."
@@ -89,8 +89,8 @@ package_qubes-vm-core() {
         gnome-settings-daemon
         gpk-update-viewer
         python-caja
-        python-nautilus
         qubes-vm-keyring
+        qubes-vm-nautilus
         qubes-vm-networking
     )
     install="archlinux/PKGBUILD.install"
@@ -105,7 +105,6 @@ package_qubes-vm-core() {
     make -C qubes-rpc DESTDIR="$pkgdir" install
     make -C qubes-rpc/caja DESTDIR="$pkgdir" install
     make -C qubes-rpc/kde DESTDIR="$pkgdir" install
-    make -C qubes-rpc/nautilus DESTDIR="$pkgdir" install
     make -C qubes-rpc/thunar DESTDIR="$pkgdir" install
     make -C filesystem DESTDIR="$pkgdir" install
 
@@ -205,6 +204,28 @@ package_qubes-vm-keyring() {
     install -m0644 "archlinux/PKGBUILD-keyring-keys" "${pkgdir}/usr/share/pacman/keyrings/qubesos-vm.gpg"
     install -m0644 "archlinux/PKGBUILD-keyring-trusted" "${pkgdir}/usr/share/pacman/keyrings/qubesos-vm-trusted"
     install -m0644 "archlinux/PKGBUILD-keyring-revoked" "${pkgdir}/usr/share/pacman/keyrings/qubesos-vm-revoked"
+}
+
+package_qubes-vm-nautilus() {
+    pkgdesc="Qubes OS Nautilus addons for inter-VM file copy/move/open"
+    conflicts=('qubes-vm-core<4.3.20')
+    depends=(
+        bash
+        python-gobject
+        python-nautilus
+        qubes-vm-core
+        qubes-vm-qrexec
+    )
+
+    cd "${_pkgnvr}"
+    make -C qubes-rpc/nautilus install \
+        DESTDIR="$pkgdir" \
+        SBINDIR=/usr/bin \
+        LIBDIR=/usr/lib \
+        SYSLIBDIR=/usr/lib \
+        SYSTEM_DROPIN_DIR=/usr/lib/systemd/system \
+        USER_DROPIN_DIR=/usr/lib/systemd/user \
+        DIST=archlinux
 }
 
 package_qubes-vm-passwordless-root() {

--- a/qubes-rpc/nautilus/Makefile
+++ b/qubes-rpc/nautilus/Makefile
@@ -6,4 +6,5 @@ QUBESLIBDIR ?= /usr/lib/qubes
 install:
 	install -d $(DESTDIR)$(NAUTILUSPYEXTDIR)
 	install -t $(DESTDIR)$(NAUTILUSPYEXTDIR) -m 0644 *.py
+	install -d $(DESTDIR)$(QUBESLIBDIR)
 	install -t $(DESTDIR)$(QUBESLIBDIR) -m 0755 *.sh


### PR DESCRIPTION
Refactor archlinux package by breaking out `qubes-vm-nautilus` from `qubes-vm-core`.

This matches existing Debian and Fedora packaging.

### Related:
- Blocking https://github.com/QubesOS/qubes-app-linux-pdf-converter/pull/34
- Same for caja and thunar: #589
- Includes #584 , #585 

---

The same could also be done for `-thunar` and `-caja`. With a tentative approval here I could address those as well, in this PR or separately.