### PR TITLE
qvm-features-request: unverbose logging of erroring qrexec calls

### DIFF
--- a/misc/qvm-features-request
+++ b/misc/qvm-features-request
@@ -99,9 +99,15 @@ def main(args=None):
 
     if args.commit:
         devnull = os.open(os.devnull, os.O_RDWR)
-        subprocess.check_call(
-            ['qrexec-client-vm', 'dom0', 'qubes.FeaturesRequest'],
-            stdin=devnull, stdout=devnull)
+        cmd = ['qrexec-client-vm', 'dom0', 'qubes.FeaturesRequest']
+        try:
+            subprocess.check_call(cmd, stdin=devnull, stdout=devnull)
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Error: Command `{' '.join(cmd)}` returned exit code {e.returncode}",
+                file=sys.stderr
+            )
+            any_error = True
 
     if any_error:
         return 1


### PR DESCRIPTION
Removes redundant stack trace from logs.

While the error caused by `hostname not found` in https://github.com/QubesOS/qubes-issues/issues/9245 is probably hinting at a separate underlying issue, this cleans up the output when errors trigger.

#### Before

```
(24/26) Updating the Qubes desktop file App Icons and features...
Traceback (most recent call last):
  File "/usr/bin/qvm-features-request", line 111, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/bin/qvm-features-request", line 102, in main
    subprocess.check_call(
  File "/usr/lib/python3.12/subprocess.py", line 413, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['qrexec-client-vm', 'dom0', 'qubes.FeaturesRequest']' returned non-zero exit status 1.
error: command failed to execute correctly
(25/26) Updating the desktop file MIME type cache...
(26/26) Updating X fontdir indices...
```

#### After

```
(24/26) Updating the Qubes desktop file App Icons and features...
Error: Command `qrexec-client-vm dom0 qubes.FeaturesRequest` returned exit code 1
error: command failed to execute correctly
(25/26) Updating the desktop file MIME type cache...
(26/26) Updating X fontdir indices...
```