### PR TITLE
arch: qubes-vm-* provide qubes-core-agent-*

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -54,6 +54,7 @@ package_qubes-vm-core() {
         echo 'invalid $pkgver'>&2
         exit 1
     }
+    provides=(qubes-core-agent=@VERSION@)
     conflicts=('pulseaudio-qubes<4.2.0')
     release=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}
     depends=(
@@ -159,6 +160,7 @@ EOF
 #
 package_qubes-vm-networking() {
     pkgdesc="Qubes OS tools allowing to use a Qubes VM as a NetVM/ProxyVM"
+    provides=(qubes-core-agent-networking=@VERSION@)
     depends=(
         conntrack-tools
         iproute2
@@ -207,6 +209,7 @@ package_qubes-vm-keyring() {
 
 package_qubes-vm-caja() {
     pkgdesc="Qubes OS Caja addons for inter-VM file copy/move/open"
+    provides=(qubes-core-agent-caja=@VERSION@)
     conflicts=('qubes-vm-core<4.3.26')
     depends=(
         bash
@@ -227,6 +230,7 @@ package_qubes-vm-caja() {
 
 package_qubes-vm-thunar() {
     pkgdesc="Qubes OS Thunar addons for inter-VM file copy/move/open"
+    provides=(qubes-core-agent-thunar=@VERSION@)
     conflicts=('qubes-vm-core<4.3.26')
     depends=(
         bash
@@ -251,6 +255,7 @@ package_qubes-vm-thunar() {
 
 package_qubes-vm-nautilus() {
     pkgdesc="Qubes OS Nautilus addons for inter-VM file copy/move/open"
+    provides=(qubes-core-agent-nautilus=@VERSION@)
     conflicts=('qubes-vm-core<4.3.26')
     depends=(
         bash
@@ -273,6 +278,7 @@ package_qubes-vm-nautilus() {
 
 package_qubes-vm-passwordless-root() {
     pkgdesc="Qubes OS Passwordless root access from normal user"
+    provides=(qubes-core-agent-passwordless-root=@VERSION@)
 
     cd "${_pkgnvr}"
     make -C passwordless-root install \
@@ -287,6 +293,7 @@ package_qubes-vm-passwordless-root() {
 
 package_qubes-vm-dom0-updates() {
     pkgdesc="Qubes OS tools for fetching dom0 updates"
+    provides=(qubes-core-agent-dom0-updates=@VERSION@)
     depends=(
         dnf5
         python

--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -60,6 +60,9 @@ def get_dns_resolved():
         dns = resolve1.Get('org.freedesktop.resolve1.Manager',
                            'DNS',
                            dbus_interface='org.freedesktop.DBus.Properties')
+        if dns is None:
+            return get_dns_resolv_conf()
+
     except dbus.exceptions.DBusException as s:
         error = s.get_dbus_name()
         if error in (


### PR DESCRIPTION
While package names match between Debian and Fedora (`qubes-core-agent{,-*}`), Arch packaging has its own naming (`qubes-vm-*`). This means that salt formulas that can otherwise be used seamlessly cross-dists need to be customized for Arch targets.

This adds `provides` directives for Arch packages so they can be installed by referring to their Debian/Fedora names.

- `qubes-core-agent` -> `qubes-vm-core`
- `qubes-core-agent-networking` -> `qubes-vm-networking`
- `qubes-core-agent-nautilus` -> `qubes-vm-nautilus`
- `qubes-core-agent-caja` -> `qubes-vm-caja`
- `qubes-core-agent-thunar` -> `qubes-vm-thunar`
- `qubes-core-agent-dom0-updates` -> `qubes-vm-dom0-updates`
- `qubes-core-agent-passwordless-root` -> `qubes-vm-passwordless-root`

`qubes-vm-keyring` unmapped.

Follow-up to #589 