### PR TITLE
fix(qubes-setup-dnat-to-ns): handle null dns dbus response

### DIFF
--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -60,6 +60,9 @@ def get_dns_resolved():
         dns = resolve1.Get('org.freedesktop.resolve1.Manager',
                            'DNS',
                            dbus_interface='org.freedesktop.DBus.Properties')
+        if dns is None:
+            return get_dns_resolv_conf()
+
     except dbus.exceptions.DBusException as s:
         error = s.get_dbus_name()
         if error in (


### PR DESCRIPTION
`resolve1.Get` dbus call is not guaranteed to return a list. This handles the case of a `None` result as equal to `[]`.

An alternative would be to fall back to `get_dns_resolv_conf` (as already done for handling known errors)

- Broken out from #592