### PR TITLE
network lint fixes

### DIFF
--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -26,7 +26,6 @@ import sys
 
 import dbus
 import qubesdb
-from typing import List
 from ipaddress import IPv4Address
 import os
 

--- a/vm-systemd/network-proxy-setup.sh
+++ b/vm-systemd/network-proxy-setup.sh
@@ -6,7 +6,7 @@
 
 # Setup gateway for all the VMs this NetVM is servicing...
 network=$(qubesdb-read /qubes-netvm-network 2>/dev/null)
-if [ "x$network" != "x" ]; then
+if [ -n "${network}" ]; then
 
     if [ -e /proc/sys/kernel ] && ! [ -e /proc/sys/kernel/modules_disabled ]; then
         readonly modprobe_fail_cmd='true'


### PR DESCRIPTION
Two minor non-functional changes:

- remove unused `List` typing import
- Use `-n` instead of x-hack for checking for empty var in shell script

#### Related

- Broken out from #592