### PR TITLE
install_firewall_rules: minor performance improvement

### DIFF
--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -112,16 +112,18 @@ def install_firewall_rules(dns):
         # Or maybe user wants to enforce DNS-Over-HTTPS.
         # Drop IPv4 DNS requests to qubesdb_dns addresses.
         for vm_nameserver in qubesdb_dns:
+            vm_ns_ = str(vm_nameserver)
             rules += [
-                f"ip daddr {vm_nameserver} udp dport 53 drop",
-                f"ip daddr {vm_nameserver} tcp dport 53 drop",
+                f"ip daddr {vm_ns_} udp dport 53 drop",
+                f"ip daddr {vm_ns_} tcp dport 53 drop",
             ]
     else:
         for vm_nameserver, dest in zip(qubesdb_dns, cycle(dns_resolved)):
+            vm_ns_ = str(vm_nameserver)
             dns_ = str(dest)
             rules += [
-                f"ip daddr {vm_nameserver} udp dport 53 dnat to {dns_}",
-                f"ip daddr {vm_nameserver} tcp dport 53 dnat to {dns_}",
+                f"ip daddr {vm_ns_} udp dport 53 dnat to {dns_}",
+                f"ip daddr {vm_ns_} tcp dport 53 dnat to {dns_}",
             ]
     rules += ["}", "}"]
 

--- a/network/qubes-setup-dnat-to-ns
+++ b/network/qubes-setup-dnat-to-ns
@@ -21,6 +21,7 @@
 
 from __future__ import annotations
 
+from itertools import cycle
 import subprocess
 import sys
 
@@ -116,10 +117,7 @@ def install_firewall_rules(dns):
                 f"ip daddr {vm_nameserver} tcp dport 53 drop",
             ]
     else:
-        while len(qubesdb_dns) > len(dns_resolved):
-            # Ensure that upstream DNS pool is larger than qubesdb_dns pool
-            dns_resolved = dns_resolved + dns_resolved
-        for vm_nameserver, dest in zip(qubesdb_dns, dns_resolved):
+        for vm_nameserver, dest in zip(qubesdb_dns, cycle(dns_resolved)):
             dns_ = str(dest)
             rules += [
                 f"ip daddr {vm_nameserver} udp dport 53 dnat to {dns_}",


### PR DESCRIPTION
- I guess the existing memoization of `dns_` is for efficiency reasons? This uses the same pattern for the other `ip_address` instance in the string `vm_nameserver`. If nothing else it makes it more consistent.
- Use `itertools.cycle` instead of list-doubling to match up `zip` side lengths.

#### Related
- Broken out from #592