### PR TITLE
network: remove redundant qubesdb-read calls and /run/qubes/qubes-ns

### DIFF
--- a/network/setup-ip
+++ b/network/setup-ip
@@ -179,12 +179,6 @@ __EOF__
 }
 
 configure_qubes_ns() {
-    gateway=$(qubesdb-read /qubes-netvm-gateway)
-    #netmask=$(qubesdb-read /qubes-netvm-netmask)
-    primary_dns=$(qubesdb-read /qubes-netvm-primary-dns 2>/dev/null || echo "$gateway")
-    secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
-    echo "NS1=$primary_dns" > /var/run/qubes/qubes-ns
-    echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
     ret=0
     /usr/lib/qubes/qubes-setup-dnat-to-ns || ret=$?
     [ "$ret" -eq 0 ] || [ "$ret" -eq 100 ] || exit "$ret"

--- a/vm-systemd/network-proxy-setup.sh
+++ b/vm-systemd/network-proxy-setup.sh
@@ -14,17 +14,11 @@ if [ "x$network" != "x" ]; then
         readonly modprobe_fail_cmd='false'
     fi
 
-    gateway=$(qubesdb-read /qubes-netvm-gateway)
-    gateway6=$(qubesdb-read /qubes-netvm-gateway6 ||:)
-    #netmask=$(qubesdb-read /qubes-netvm-netmask)
-    primary_dns=$(qubesdb-read /qubes-netvm-primary-dns 2>/dev/null || echo "$gateway")
-    secondary_dns=$(qubesdb-read /qubes-netvm-secondary-dns)
     modprobe netbk 2> /dev/null || modprobe xen-netback || "${modprobe_fail_cmd}"
-    echo "NS1=$primary_dns" > /var/run/qubes/qubes-ns
-    echo "NS2=$secondary_dns" >> /var/run/qubes/qubes-ns
     /usr/lib/qubes/qubes-setup-dnat-to-ns
     echo "1" > /proc/sys/net/ipv4/ip_forward
     # enable also IPv6 forwarding, if IPv6 is enabled
+    gateway6=$(qubesdb-read /qubes-netvm-gateway6 ||:)
     if [ -n "$gateway6" ]; then
         echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
     fi


### PR DESCRIPTION
The file `/var/run/qubes/qubes-ns` is not used since the transition to nftables (https://github.com/QubesOS/qubes-core-agent-linux/pull/407/files#diff-1e7c156682261fecd8a773620728327528f3be00468837709d7ffeb8073cc602L17).
Remove it and the associated now redundant `qubesdb-read` calls.

`qubes-ns` is also no longer used in qubes-whonix: https://github.com/Whonix/qubes-whonix/commit/451b784c6db5316289e16ac18fd496851f4c3a92