### PR TITLE
boot: move qubes-serial-login to /usr/bin

### DIFF
--- a/boot/redhat/Makefile
+++ b/boot/redhat/Makefile
@@ -1,6 +1,6 @@
 DATADIR ?= /usr/share
 LIBDIR ?= /usr/lib
-SBINDIR ?= /usr/sbin
+BINDIR ?= /usr/bin
 SYSCONFDIR ?= /etc
 QUBESDATADIR = $(DATADIR)/qubes
 
@@ -10,4 +10,4 @@ install:
 	install -D -m 0644 session-stop-timeout.conf \
 		$(DESTDIR)$(LIBDIR)/systemd/system/user@.service.d/90-session-stop-timeout.conf
 	install -D -m 0644 serial.conf $(DESTDIR)$(QUBESDATADIR)/serial.conf
-	install -D qubes-serial-login $(DESTDIR)$(SBINDIR)/qubes-serial-login
+	install -D qubes-serial-login $(DESTDIR)$(BINDIR)/qubes-serial-login

--- a/boot/redhat/serial.conf
+++ b/boot/redhat/serial.conf
@@ -18,4 +18,4 @@ stop on runlevel [016]
 instance $DEV
 respawn
 pre-start exec /sbin/securetty $DEV
-exec /sbin/agetty -l /usr/sbin/qubes-serial-login /dev/$DEV $SPEED vt100-nav
+exec /sbin/agetty -l /usr/bin/qubes-serial-login /dev/$DEV $SPEED vt100-nav

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1001,7 +1001,7 @@ rm -f %{name}-%{version}
 /usr/lib/sysctl.d/20-qubes-core.conf
 %_udevrulesdir/50-qubes-mem-hotplug.rules
 %_unitdir/user@.service.d/90-session-stop-timeout.conf
-/usr/sbin/qubes-serial-login
+%_bindir/qubes-serial-login
 %_bindir/qvm-copy-to-vm
 %_bindir/qvm-move-to-vm
 %_bindir/qvm-copy


### PR DESCRIPTION
Fedora 42+ merges /usr/sbin to /usr/bin.
I hope this fixes `/usr/sbin cannot be merged` message during system update.