### PR TITLE
minimal-vms: disable GVFS usage for GIO clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,8 @@ install-systemd: install-init
 		$(DESTDIR)$(SYSLIBDIR)/modules-load.d \
 		$(DESTDIR)/etc/systemd/system \
 		$(DESTDIR)$(SYSLIBDIR)/systemd/network \
-		$(DESTDIR)$(SYSLIBDIR)/systemd/resolved.conf.d/
+		$(DESTDIR)$(SYSLIBDIR)/systemd/resolved.conf.d/ \
+		$(DESTDIR)$(SYSLIBDIR)/systemd/system-environment-generators
 	install -m 0644 $(SYSTEMD_CORE_SERVICES) $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/qubes-*.timer $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/75-qubes-vm.preset $(DESTDIR)$(SYSLIBDIR)/systemd/system-preset/
@@ -167,6 +168,7 @@ install-systemd: install-init
 	install -m 0644 vm-systemd/30_resolved-no-mdns-or-llmnr.conf $(DESTDIR)$(SYSLIBDIR)/systemd/resolved.conf.d/
 	install -m 0644 vm-systemd/home.mount $(DESTDIR)$(SYSLIBDIR)/systemd/system/
 	install -m 0644 vm-systemd/usr-local.mount $(DESTDIR)$(SYSLIBDIR)/systemd/system/
+	install -m 0755 vm-systemd/system-environment-generators/30-qubes.sh $(DESTDIR)$(SYSLIBDIR)/systemd/system-environment-generators/30-qubes.sh
 
 .PHONY: install-sysvinit
 install-sysvinit: install-init

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -117,6 +117,7 @@ lib/systemd/system/systemd-timesyncd.service.d/30_qubes.conf
 lib/systemd/system/systemd-logind.service.d/30_qubes.conf
 lib/systemd/system/systemd-nsresourced.service.d/30_qubes.conf
 lib/systemd/system/systemd-nsresourced.socket.d/30_qubes.conf
+lib/systemd/system-environment-generators/30-qubes.sh
 lib/systemd/resolved.conf.d/30_resolved-no-mdns-or-llmnr.conf
 lib/systemd/system/home.mount
 lib/systemd/system/usr-local.mount

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1255,6 +1255,7 @@ The Qubes core startup configuration for SystemD init.
 %_userunitdir/gvfs-daemon.service.d/30_qubes.conf
 %_userunitdir/pipewire.service.d/40_minimal.conf
 %_userunitdir/wireplumber.service.d/30_qubes.conf
+/usr/lib/systemd/system-environment-generators/30-qubes.sh
 
 %post systemd
 

--- a/vm-systemd/system-environment-generators/30-qubes.sh
+++ b/vm-systemd/system-environment-generators/30-qubes.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Disable GVFS usage for GIO clients
+if [ -f /run/qubes-service/minimal-netvm ] || [ -f /run/qubes-service/minimal-usbvm ]; then
+  echo "GIO_USE_VFS=local"
+fi


### PR DESCRIPTION
This causes timeouts as gvfs daemon is disabled for VMs having this feature enabled as mentioned here: https://github.com/QubesOS/qubes-issues/issues/10165 