### PR TITLE
Add distinct GUI bookmark package

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -1,6 +1,6 @@
 # Maintainer: Frédéric Pierret (fepitre) <frederic@invisiblethingslab.com>
 
-pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring qubes-vm-caja qubes-vm-nautilus qubes-vm-passwordless-root qubes-vm-thunar qubes-vm-dom0-updates)
+pkgname=(qubes-vm-core qubes-vm-networking qubes-vm-keyring qubes-vm-bookmark qubes-vm-caja qubes-vm-nautilus qubes-vm-passwordless-root qubes-vm-thunar qubes-vm-dom0-updates)
 pkgver=@VERSION@
 pkgrel=@REL@
 pkgdesc="The Qubes core files for installation inside a Qubes VM."
@@ -95,6 +95,7 @@ package_qubes-vm-core() {
         qubes-vm-nautilus
         qubes-vm-networking
         qubes-vm-thunar
+        qubes-vm-bookmark
     )
     install="archlinux/PKGBUILD.install"
 
@@ -220,6 +221,22 @@ package_qubes-vm-caja() {
 
     cd "${_pkgnvr}"
     make -C qubes-rpc/caja install \
+        DESTDIR="$pkgdir" \
+        SBINDIR=/usr/bin \
+        LIBDIR=/usr/lib \
+        SYSLIBDIR=/usr/lib \
+        SYSTEM_DROPIN_DIR=/usr/lib/systemd/system \
+        USER_DROPIN_DIR=/usr/lib/systemd/user \
+        DIST=archlinux
+}
+
+package_qubes-vm-bookmark() {
+    pkgdesc="Qubes integration for GUI bookmarks"
+    provides=(qubes-core-agent-bookmark=@VERSION@)
+    conflicts=('qubes-vm-core<4.3.26')
+
+    cd "${_pkgnvr}"
+    make -C qubes-rpc/bookmark install \
         DESTDIR="$pkgdir" \
         SBINDIR=/usr/bin \
         LIBDIR=/usr/lib \

--- a/debian/control
+++ b/debian/control
@@ -87,11 +87,19 @@ Description: Qubes core agent
  This package includes various daemons necessary for qubes domU support,
  such as qrexec services.
 
+Package: qubes-core-agent-bookmark
+Architecture: any
+Replaces: qubes-core-agent (<< 4.0.0-1)
+Breaks: qubes-core-agent (<< 4.0.0-1)
+Description: Qubes integration for GUI bookmarks
+ GUI bookmarks for useful Qubes OS directories.
+
 Package: qubes-core-agent-nautilus
 Architecture: any
 Depends:
     ${pythonver:Depends}-nautilus,
     qubes-core-qrexec,
+    qubes-core-agent-bookmark,
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: Qubes integration for Nautilus
@@ -102,6 +110,7 @@ Architecture: any
 Depends:
     ${pythonver:Depends}-caja,
     qubes-core-qrexec,
+    qubes-core-agent-bookmark,
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: Qubes integration for Caja
@@ -112,6 +121,7 @@ Architecture: any
 Depends:
     thunar,
     qubes-core-qrexec,
+    qubes-core-agent-bookmark,
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: Qubes integration for Thunar
@@ -122,6 +132,7 @@ Architecture: any
 Depends:
     pcmanfm-qt,
     qubes-core-qrexec,
+    qubes-core-agent-bookmark,
 Replaces: qubes-core-agent (<< 4.0.0-1)
 Breaks: qubes-core-agent (<< 4.0.0-1)
 Description: Qubes integration for PCManFM-Qt

--- a/debian/qubes-core-agent-bookmarks.install
+++ b/debian/qubes-core-agent-bookmarks.install
@@ -1,0 +1,1 @@
+usr/lib/qubes/qvm_bookmark.sh

--- a/debian/qubes-core-agent-nautilus.install
+++ b/debian/qubes-core-agent-nautilus.install
@@ -1,2 +1,1 @@
 usr/share/nautilus-python/extensions/*
-usr/lib/qubes/qvm_nautilus_bookmark.sh

--- a/qubes-rpc/bookmark/Makefile
+++ b/qubes-rpc/bookmark/Makefile
@@ -1,0 +1,7 @@
+QUBESLIBDIR ?= /usr/lib/qubes
+
+.PHONY: install
+
+install:
+	install -d $(DESTDIR)$(QUBESLIBDIR)
+	install -t $(DESTDIR)$(QUBESLIBDIR) -m 0755 *.sh

--- a/qubes-rpc/bookmark/qvm_bookmark.sh
+++ b/qubes-rpc/bookmark/qvm_bookmark.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+incoming_dir="$HOME/QubesIncoming"
+bookmark_created_basename="qubes-incoming-bookmark-created"
+
+dir="$HOME/.config/gtk-3.0"
+test -d "$dir" || exit 0
+created="$dir/$bookmark_created_basename"
+! test -e "$created" || exit 0
+printf '%s\n' "file://$incoming_dir" >> "$dir"/bookmarks
+touch -- "$created"

--- a/qubes-rpc/nautilus/Makefile
+++ b/qubes-rpc/nautilus/Makefile
@@ -7,4 +7,3 @@ install:
 	install -d $(DESTDIR)$(NAUTILUSPYEXTDIR)
 	install -t $(DESTDIR)$(NAUTILUSPYEXTDIR) -m 0644 *.py
 	install -d $(DESTDIR)$(QUBESLIBDIR)
-	install -t $(DESTDIR)$(QUBESLIBDIR) -m 0755 *.sh

--- a/qubes-rpc/nautilus/qvm_nautilus_bookmark.sh
+++ b/qubes-rpc/nautilus/qvm_nautilus_bookmark.sh
@@ -1,6 +1,0 @@
-#!/bin/sh
-if [ ! -e ~/.config/gtk-3.0/qubes-incoming-bookmark-created ]
-then
-  echo "file:///home/user/QubesIncoming" >> ~/.config/gtk-3.0/bookmarks
-  touch ~/.config/gtk-3.0/qubes-incoming-bookmark-created
-fi

--- a/qubes-rpc/qubes.Filecopy
+++ b/qubes-rpc/qubes.Filecopy
@@ -1,7 +1,7 @@
 #!/bin/sh
-if [ -f /usr/lib/qubes/qvm_nautilus_bookmark.sh ]
+if [ -f /usr/lib/qubes/qvm_bookmark.sh ]
 then
-  /usr/lib/qubes/qvm_nautilus_bookmark.sh >/dev/null 2>&1 </dev/null
+  /usr/lib/qubes/qvm_bookmark.sh >/dev/null 2>&1 </dev/null
 fi
 case $1 in
 ('') arg=;;

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -260,9 +260,18 @@ DNF plugin for Qubes specific post-installation actions:
 %endif
 %endif
 
+%package bookmark
+Summary:    Qubes integration for GUI bookmarks
+Requires:   qubes-core-agent = %{version}
+Conflicts:  qubes-core-vm < 4.0.0
+
+%description bookmark
+GUI bookmarks for useful Qubes OS directories.
+
 %package caja
 Summary:    Qubes integration for Caja
 Requires:   qubes-core-agent = %{version}
+Requires:   qubes-core-agent-bookmark = %{version}
 %if 0%{?is_opensuse}
 Requires:   python-caja
 %else
@@ -280,6 +289,7 @@ Caja addons for inter-VM file copy/move/open.
 %package nautilus
 Summary:    Qubes integration for Nautilus
 Requires:   qubes-core-agent = %{version}
+Requires:   qubes-core-agent-bookmark = %{version}
 %if 0%{?is_opensuse}
 Requires:   python-nautilus-common-files
 %else
@@ -293,6 +303,14 @@ BuildRequires: python-nautilus-common-files
 
 %description nautilus
 Nautilus addons for inter-VM file copy/move/open.
+
+%package thunar
+Summary:    Thunar support for Qubes VM tools
+Requires:   Thunar
+Requires:   qubes-core-agent-bookmark = %{version}
+
+%description thunar
+Thunar support for Qubes VM tools
 
 %package dom0-updates
 BuildArch:  noarch
@@ -372,13 +390,6 @@ Configure sudo, PolicyKit and similar tool to not ask for any password when
 switching from user to root. Since all the user data in a VM is accessible
 already from normal user account, there is not much more to guard there. Qubes
 VMs are single user systems.
-
-%package thunar
-Summary: Thunar support for Qubes VM tools
-Requires: Thunar
-
-%description thunar
-Thunar support for Qubes VM tools
 
 %if %{with selinux}
 %package selinux
@@ -504,6 +515,7 @@ make -C qubes-rpc/kde DESTDIR=$RPM_BUILD_ROOT install-kde4
 make -C qubes-rpc/kde DESTDIR=$RPM_BUILD_ROOT install-kde5
 make -C qubes-rpc/nautilus DESTDIR=$RPM_BUILD_ROOT install
 make -C qubes-rpc/thunar DESTDIR=$RPM_BUILD_ROOT install
+make -C qubes-rpc/bookmark DESTDIR=$RPM_BUILD_ROOT install
 
 %if 0%{?fedora} >= 41
 make -C package-managers PYTHON=%{__python3} DESTDIR=$RPM_BUILD_ROOT install install-dnf5
@@ -1097,6 +1109,9 @@ rm -f %{name}-%{version}
 %endif
 %endif
 
+%files bookmark
+/usr/lib/qubes/qvm_bookmark.sh
+
 %files caja
 /usr/share/caja-python/extensions/qvm_copy_caja.py*
 /usr/share/caja-python/extensions/qvm_move_caja.py*
@@ -1106,7 +1121,6 @@ rm -f %{name}-%{version}
 /usr/share/nautilus-python/extensions/qvm_copy_nautilus.py*
 /usr/share/nautilus-python/extensions/qvm_move_nautilus.py*
 /usr/share/nautilus-python/extensions/qvm_dvm_nautilus.py*
-/usr/lib/qubes/qvm_nautilus_bookmark.sh
 
 %files thunar
 /usr/lib/qubes/qvm-actions.sh


### PR DESCRIPTION
GTK bookmarks can be used by all currently supported file managers:

- caja
- thunar
- nautilus
- pcmanfm-qt (yes, it has a fallback for gtk bookmarks)

For: https://github.com/QubesOS/qubes-issues/issues/10081

---

Didn't name GTK because I wish to maintain it framework free. Because pcmanfm-qt is using GTK bookmark as fallback, there is currently no need for a QT workaround.