### PR TITLE
dom0-update: In download mode, only send specifically requested packages to dom0

### DIFF
--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -168,16 +168,68 @@ if [ "$UPDATE_ACTION" = "download" ];  then
 fi
 
 set -e
+set -o pipefail
 
-"${UPDATE_COMMAND[@]}" "${OPTS[@]}" "${PKGLIST[@]}"
+"${UPDATE_COMMAND[@]}" "${OPTS[@]}" "${PKGLIST[@]}" | \
+  tee "$DOM0_UPDATES_DIR/download.out"
 
+# Collect rpms from various download locations into one directory
 find "$DOM0_UPDATES_DIR/var/cache" -name '*.rpm' -print0 2>/dev/null |\
     xargs -0 -r ln -f -t "$DOM0_UPDATES_DIR/packages/"
 
-if ls "$DOM0_UPDATES_DIR"/packages/*.rpm > /dev/null 2>&1; then
+case "$UPDATE_ACTION" in
+    # Never send package to dom0 for the following commands. This by no
+    # means is an exhaustive list, just some common ones.
+    changelog|list|search) ;;
+    # TODO: Look for any other commands that download packages and add
+    # NOTE: For now, use the fallback for distro-sync because its output
+    # may have some untested corner cases. So being conservative.
+    downgrade|download|install|upgrade)
+        RPMS=$(
+            grep '^ ' "$DOM0_UPDATES_DIR/download.out" |
+            tail -n +2 |
+            while read -r PKG ARCH VER _REPO _SIZE; do
+                # Assumption: Package names do not contain spaces
+                F="$PKG-${VER##*:}.$ARCH.rpm"
+                if [ -f "$DOM0_UPDATES_DIR"/packages/"$F" ]; then
+                    echo "$F"
+                else
+                    # Did not find package that was supposed to be downloaded... bail
+                    echo "Package $F requested but not downloaded" >&2
+                    exit 1
+                fi
+            done
+        ) || RET=$?
+        if [ -z "$RPMS" ]; then
+            cat >&2 <<EOF
+No packages found in output for action $UPDATE_ACTION. This is likely
+due to a change in the output format. Falling back to old method that
+sends all verified packages in the package cache.
+Output:
+EOF
+            cat "$DOM0_UPDATES_DIR/download.out" >&2
+        fi
+        if [ "${RET:-0}" -ne 0 ] || [ "$CLEAN" = "1" ]; then
+            # An error occured in determining or finding requested packages
+            # or --clean was specified, unset RPM to fallback to old method.
+            RPMS=
+        fi
+
+        ;&
+    # Fallback to previous implementation of uploading all verified rpms
+    # for all other actions and above failure condition.
+    *)
+        if [ -z "$RPMS" ]; then
+            RPMS=$(for P in "$DOM0_UPDATES_DIR"/packages/*.rpm; do echo "${P##*/}"; done)
+        fi
+        ;;
+esac
+
+if [ -n "$RPMS" ]; then
     if [ -n "$SIGNATURE_REGEX" ]; then
         rpmkeys_error=0
-        for pkg in "$DOM0_UPDATES_DIR"/packages/*.rpm; do
+        for rpmfile in $RPMS; do
+            pkg="$DOM0_UPDATES_DIR"/packages/"$rpmfile"
             rpmkeys_exit_code=0
             output="$(rpmkeys --root "$DOM0_UPDATES_DIR" --checksig "$pkg")" \
                 || rpmkeys_exit_code="$?"
@@ -185,7 +237,7 @@ if ls "$DOM0_UPDATES_DIR"/packages/*.rpm > /dev/null 2>&1; then
                 echo "ERROR: could not verify $pkg" >&2
                 rpmkeys_error=1
                 rm "$pkg"
-            elif ! echo "$output" |grep -Pq "$SIGNATURE_REGEX"; then
+            elif ! echo "$output" | grep -Pq "$SIGNATURE_REGEX"; then
                 echo "ERROR: missing or invalid signature for $pkg" >&2
                 rpmkeys_error=1
                 rm "$pkg"
@@ -201,11 +253,14 @@ if ls "$DOM0_UPDATES_DIR"/packages/*.rpm > /dev/null 2>&1; then
 
     cmd="/usr/lib/qubes/qrexec-client-vm dom0 qubes.ReceiveUpdates /usr/lib/qubes/qfile-agent"
     qrexec_exit_code=0
-    $cmd "$DOM0_UPDATES_DIR"/packages/*.rpm || { qrexec_exit_code=$? ; true; };
+    rpmfiles=$(for rpmfile in $RPMS; do echo "$DOM0_UPDATES_DIR"/packages/"$rpmfile"; done)
+    # shellcheck disable=SC2086
+    $cmd $rpmfiles || { qrexec_exit_code=$? ; true; };
     if [ ! "$qrexec_exit_code" = "0" ]; then
-        echo "'$cmd $DOM0_UPDATES_DIR/packages/*.rpm' failed with exit code ${qrexec_exit_code}!" >&2
+        echo "'$cmd $rpmfiles' failed with exit code ${qrexec_exit_code}!" >&2
         exit "$qrexec_exit_code"
     fi
 else
     echo "No packages downloaded" >&2
 fi
+rm -f "$DOM0_UPDATES_DIR/download.out"

--- a/package-managers/qubes-download-dom0-updates.sh
+++ b/package-managers/qubes-download-dom0-updates.sh
@@ -220,7 +220,13 @@ EOF
     # for all other actions and above failure condition.
     *)
         if [ -z "$RPMS" ]; then
-            RPMS=$(for P in "$DOM0_UPDATES_DIR"/packages/*.rpm; do echo "${P##*/}"; done)
+            RPMS=$(
+                for P in "$DOM0_UPDATES_DIR"/packages/*.rpm; do
+                    if [ -e "$P" ]; then
+                        echo "${P##*/}"
+                    fi
+                done
+            )
         fi
         ;;
 esac


### PR DESCRIPTION
Currently [`qubes-download-dom0-updates.sh`](https://github.com/QubesOS/qubes-core-agent-linux/blob/2e5866fdb23c49ffa78b871fe37bdf3aa77fddaf/package-managers/qubes-download-dom0-updates.sh#L204) will send to dom0 all files with a `.rpm` file extension to dom0 to be installed by the package manager. Because interrupting the qubes-dom0-update does not stop the UpdateVM from downloading requested packages (QubesOS/qubes-issues#10722), the files sent back to dom0 to be installed by the package manager may be more than was actually requested. This could cause unintended installs or [installation failures](https://github.com/QubesOS/qubes-issues/issues/10716).

This PR changes `qubes-download-dom0-updates.sh` to only send packages that were requested. This is done by parsing the output of the package manager to extract package filenames. This was tested on Qubes 4.3, with the UpdateVM being sys-whonix.

`sys-whonix` uses `dnf`, but it appears that the script needs to support `yum` and `dnf5`. Those have not been explicitly tested. dnf5 from fedora 41 appears to have sufficiently similar output and I'd expect the output to be pretty stable.

Fixes QubesOS/qubes-issues#10716