### PR TITLE
don't resize volatile root

### DIFF
--- a/init/resize-rootfs-if-needed.sh
+++ b/init/resize-rootfs-if-needed.sh
@@ -11,6 +11,14 @@ if [ "$(blockdev --getro /dev/xvda)" -eq "1" ]; then
     exit 0
 fi
 
+# if root volume is a volatile snapshot (AppVM/DispVM), skip resize —
+# it must happen in the TemplateVM where changes persist
+vm_type=$(qubesdb-read /qubes-vm-type 2>/dev/null || true)
+if [ "$vm_type" = "AppVM" ] || [ "$vm_type" = "DispVM" ]; then
+    echo "volatile root volume ($vm_type), skipping resize" >&2
+    exit 0
+fi
+
 sysfs_xvda="/sys/class/block/xvda"
 
 # if root filesystem is already using (almost) the whole disk


### PR DESCRIPTION
Fixes https://github.com/QubesOS/qubes-issues/issues/10503

If we resized a TemplateVM but never booted it, then boot an AppVM that depends on the template, `resize-rootfs-if-needed.sh` will resize the volatile root volume through CoW, which is very slow and likely unexpected.

This skips resizing root volumes for AppVMs and DispVMs.

Note: I'm not sure this is the best way to do that and would appreciate feedback - for instance if there was away to explicitly check whether the root volume is volatile rather than hardcoding VM classes..


Note: from an User Experience pt of view this is still iffy - less technical users will not expect to have to run the TemplateVM once to apply the resizing changes - but it's a separate issue.