### PR TITLE
Fix missing deprecation warning for qvm-copy-to-vm

### DIFF
--- a/qubes-rpc/qvm-copy
+++ b/qubes-rpc/qvm-copy
@@ -87,6 +87,7 @@ done
 if [ "$#" -lt "$MIN_ARGS" ]; then usage 1; fi
 
 if [ "$TARGET_TYPE" = "vm" ]; then
+  echo "In order to avoid typing target qube name twice, use qvm-copy/qvm-move instead of qvm-copy-to-vm/qvm-move-to-vm." >&2
   VM="$1"
   shift
 else


### PR DESCRIPTION
This adds the missing warning message to the main execution flow when TARGET_TYPE is "vm", as suggested by @marmarek.

Fixes QubesOS/qubes-issues#9615