### PR TITLE
Add extrepo with offline data support for Debian templates

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -62,6 +62,8 @@ Depends:
     ${misc:Depends},
 Recommends:
     cups,
+    extrepo,
+    extrepo-offline-data,
     gnome-terminal,
     gnome-themes-standard,
     haveged,

--- a/debian/control
+++ b/debian/control
@@ -62,8 +62,6 @@ Depends:
     ${misc:Depends},
 Recommends:
     cups,
-    extrepo,
-    extrepo-offline-data,
     gnome-terminal,
     gnome-themes-standard,
     haveged,
@@ -80,11 +78,14 @@ Recommends:
     xserver-xorg-core,
     xsettingsd,
     xterm,
+Provides:
+    ${diverted-files},
 Conflicts:
     pulseaudio-qubes (<< 4.2.0-1),
     qubes-core-agent-linux,
     qubes-core-vm-sysvinit,
     qubes-gui-agent (<< 4.1.6-1),
+    ${diverted-files},
 Description: Qubes core agent
  This package includes various daemons necessary for qubes domU support,
  such as qrexec services.

--- a/debian/qubes-core-agent.displace
+++ b/debian/qubes-core-agent.displace
@@ -1,0 +1,1 @@
+/etc/extrepo/config.yaml.qubes

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -3,7 +3,7 @@ etc/apt/apt.conf.d/10no-cache
 etc/apt/apt.conf.d/41error-on-any
 etc/apt/apt.conf.d/70no-unattended
 etc/apt/sources.list.d/qubes-r4.list
-etc/extrepo/config.yaml
+etc/extrepo/config.yaml.qubes
 etc/dconf/db/local.d/dpi
 etc/default/grub.d/30-qubes.cfg
 etc/fstab

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -3,6 +3,7 @@ etc/apt/apt.conf.d/10no-cache
 etc/apt/apt.conf.d/41error-on-any
 etc/apt/apt.conf.d/70no-unattended
 etc/apt/sources.list.d/qubes-r4.list
+etc/extrepo/config.yaml
 etc/dconf/db/local.d/dpi
 etc/default/grub.d/30-qubes.cfg
 etc/fstab

--- a/debian/rules
+++ b/debian/rules
@@ -42,6 +42,7 @@ override_dh_systemd_start:
 override_dh_install:
 	if [ "$(DISTRIBUTION)" = "Ubuntu" ]; then \
 		sed -i '/defaults.list/d' debian/qubes-core-agent.install; \
+		sed -i '/extrepo/d' debian/qubes-core-agent.install; \
 	fi
 	dh_install --fail-missing
 

--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -85,7 +85,7 @@ endif
 ifneq ($(DIST_NAME),Ubuntu)
 	install -d $(DESTDIR)$(SYSCONFDIR)/extrepo
 	sed "s/@DIST@/$(DIST)/" extrepo-qubes-config.yaml.in \
-		> $(DESTDIR)$(SYSCONFDIR)/extrepo/config.yaml
+		> $(DESTDIR)$(SYSCONFDIR)/extrepo/config.yaml.qubes
 endif
 
 install-dnf: install-rpm

--- a/package-managers/Makefile
+++ b/package-managers/Makefile
@@ -82,6 +82,11 @@ endif
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/10no-cache
 	install -D -m 0644 apt-conf-41error-on-any \
 		$(DESTDIR)$(APTCONFDIR)/apt.conf.d/41error-on-any
+ifneq ($(DIST_NAME),Ubuntu)
+	install -d $(DESTDIR)$(SYSCONFDIR)/extrepo
+	sed "s/@DIST@/$(DIST)/" extrepo-qubes-config.yaml.in \
+		> $(DESTDIR)$(SYSCONFDIR)/extrepo/config.yaml
+endif
 
 install-dnf: install-rpm
 ifeq ($(shell rpm --eval %{centos_ver} 2>/dev/null),8)

--- a/package-managers/extrepo-qubes-config.yaml.in
+++ b/package-managers/extrepo-qubes-config.yaml.in
@@ -1,0 +1,8 @@
+---
+url: file:///usr/share/extrepo/offline-data
+dist: debian
+version: @DIST@
+enabled_policies:
+- main
+- contrib
+- non-free


### PR DESCRIPTION
A Qubes-specific extrepo configuration for Debian templates, using `config-package-dev` displacement so it does not conflict with the `extrepo` package's own `/etc/extrepo/config.yaml`.

The installed config points extrepo at the local offline data instead of fetching from the network. 

This allows users to safely enable external repositories (e.g. Signal, Element) in templates without requiring direct network access or manually managing GPG keys. All three policies (`main`, `contrib`, `non-free`) are enabled.

The config is only installed for Debian, since extrepo is a Debian-specific tool.

closes: https://github.com/QubesOS/qubes-issues/issues/9758