### PR TITLE
dnf: avoid deadlock on repository lock after successful update

### DIFF
--- a/package-managers/qubes-post-update.actions
+++ b/package-managers/qubes-post-update.actions
@@ -1,4 +1,4 @@
 # notify dom0 if all updates are installed now
-post_transaction:::enabled=host-only:/usr/lib/qubes/upgrades-status-notify
+post_transaction:::enabled=host-only:/usr/lib/qubes/upgrades-status-notify skip-refresh
 # refresh appmenus, features etc
 post_transaction:::enabled=host-only:/etc/qubes-rpc/qubes.PostInstall

--- a/package-managers/upgrades-installed-check
+++ b/package-managers/upgrades-installed-check
@@ -22,8 +22,15 @@ if [ -e /etc/system-release ]; then
     else
         yum=yum
     fi
+    dnf_opts=()
+    if $skip_refresh; then
+        dnf_opts+=(--cacheonly)
+        if dnf --help|grep -q skip-file-locks; then
+            dnf_opts+=(--skip-file-locks)
+        fi
+    fi
     # shellcheck disable=SC2034
-    yum_output="$($yum -yq check-update)"
+    yum_output="$($yum -yq "${dnf_opts[@]}" check-update)"
     exit_code="$?"
     [ "$exit_code" -eq 100 ] && echo "false" && exit 0
     [ "$exit_code" -eq 0 ] && echo "true"


### PR DESCRIPTION
After successful update (or installing packages), the post transaction
hook sends notification to dom0 about remaining updates (which may be
zero). For that, it calls `dnf -qy check-update`. DNF5 in Fedora 44
takes a lock on the system repository for this, and since that hook is
called by DNF5 already, it causes a deadlock.

Avoid the deadlock by adding --skip-file-locks options. And to make it
safe (or at least safer), do it only if operating on cached repository
metadata, not when refreshing it.

QubesOS/qubes-issues#10703