### PR TITLE
Disable geoclue

### DIFF
--- a/autostart-dropins/geoclue-demo-agent.desktop
+++ b/autostart-dropins/geoclue-demo-agent.desktop
@@ -1,0 +1,2 @@
+[Desktop Entry]
+NotShowIn=X-QUBES;


### PR DESCRIPTION
It isn't really used, but take 5-10MB of RAM.

QubesOS/qubes-issues#7028