### PR TITLE
network: adjust interface names in NM connections after update to R4.3 (cont)

### DIFF
--- a/network/network-manager-prepare-conf-dir
+++ b/network/network-manager-prepare-conf-dir
@@ -19,8 +19,12 @@ for conn in "$NM_CONFIG_DIR"/*.nmconnection; do
     if [ -z "$intf" ]; then
         continue
     fi
-    new_intf="${intf%f0}"
-    if ! [ -e "/sys/class/net/$intf" ] && [ -e "/sys/class/net/$new_intf" ]; then
+    if [ -e "/sys/class/net/$intf" ]; then
+        # device exists, no need to change
+        continue
+    fi
+    new_intf="$(echo "${intf}" | sed -e s/f0//)"
+    if [ -e "/sys/class/net/$new_intf" ]; then
         sed -i "s/^interface-name=$intf/interface-name=$new_intf/" "$conn"
     fi
 done


### PR DESCRIPTION
Handle also multi-port devices, where "f0" may not be at the end of the
interface name.

Fixes QubesOS/qubes-issues#10154
