### PR TITLE
Disable zram on minimal netvm/usbvm

### DIFF
--- a/vm-systemd/setup-minimal-vm
+++ b/vm-systemd/setup-minimal-vm
@@ -33,7 +33,20 @@ setup_minimal_netvm() {
 	fi
 }
 
+disable_zram() {
+    systemctl mask --runtime --now systemd-zram-setup@zram0
+    ln -nsf /dev/null /run/systemd/zram-generator.conf
+    systemctl daemon-reload
+    if command -v zramctl >/dev/null; then
+        zramctl -r zram0
+    fi
+}
+
 if is_minimal_netvm; then
 	setup_minimal_netvm
+    disable_zram
 fi
 
+if is_minimal_usbvm; then
+    disable_zram
+fi


### PR DESCRIPTION
Those run with minimal amount of memory, and there is no place to spare
some for compressed swap. Real swap is slower, but it's still better
than killing processes on OOM...

QubesOS/qubes-issues#10703
