### PR TITLE
Reduce udev max children count on minimal VMs

### DIFF
--- a/vm-systemd/setup-minimal-vm
+++ b/vm-systemd/setup-minimal-vm
@@ -42,11 +42,17 @@ disable_zram() {
     fi
 }
 
+limit_udev() {
+    udevadm control --children-max=2
+}
+
 if is_minimal_netvm; then
 	setup_minimal_netvm
+    limit_udev
     disable_zram
 fi
 
 if is_minimal_usbvm; then
+    limit_udev
     disable_zram
 fi


### PR DESCRIPTION
Udev child uses between 2-5 MB each. With the default of 10, that's
significant part of memory of sys-net/sys-usb. Reduce to 2. This will
slow down startup a bit, but since those VMs have 2 vCPUs by default
anyway, not by much.

https://github.com/QubesOS/qubes-issues/issues/10886
