### PR TITLE
Restart qubes-firewall on failure

### DIFF
--- a/vm-systemd/qubes-firewall.service
+++ b/vm-systemd/qubes-firewall.service
@@ -7,6 +7,8 @@ Before=qubes-network.service
 [Service]
 Type=notify-reload
 ExecStart=/usr/bin/qubes-firewall
+Restart=on-failure
+RestartSec=5s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Sometimes, on a small sys-net, qubes-firewall gets killed by OOM killer,
if it happens to start and reload rules at the time when many other
services are starting. This results in no network access to downstream
VMs.
Restart it on failure automatically, but with 5s delay.

QubesOS/qubes-issues#10886
