### PR TITLE
Fix PackageKit offline error in Debian templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,7 @@ SYSTEM_DROPINS += abrtd.service
 SYSTEM_DROPINS += bluetooth.service
 SYSTEM_DROPINS += systemd-nsresourced.service
 SYSTEM_DROPINS += systemd-nsresourced.socket
+SYSTEM_DROPINS += packagekit.service
 
 SYSTEM_DROPINS_NETWORKING := NetworkManager.service NetworkManager-wait-online.service
 SYSTEM_DROPINS_NETWORKING += tinyproxy.service

--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -95,6 +95,7 @@ lib/systemd/system/org.cups.cupsd.path.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.service.d/30_qubes.conf
 lib/systemd/system/org.cups.cupsd.socket.d/30_qubes.conf
 lib/systemd/system/polkit.service.d/30_qubes.conf
+lib/systemd/system/packagekit.service.d/30_qubes.conf
 lib/systemd/system/dev-xvdc1-swap.service
 lib/systemd/system/qubes-bind-dirs.service
 lib/systemd/system/qubes-early-vm-config.service

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1256,6 +1256,7 @@ The Qubes core startup configuration for SystemD init.
 %_unitdir/ModemManager.service.d/30_qubes.conf
 %_unitdir/NetworkManager.service.d/30_qubes.conf
 %_unitdir/NetworkManager-wait-online.service.d/30_qubes.conf
+%_unitdir/packagekit.service.d/30_qubes.conf
 %_unitdir/polkit.service.d/30_qubes.conf
 %_unitdir/serial-getty@.service.d/30_qubes.conf
 %_unitdir/systemd-random-seed.service.d/30_qubes.conf

--- a/vm-systemd/packagekit.service.d/30_qubes.conf
+++ b/vm-systemd/packagekit.service.d/30_qubes.conf
@@ -1,0 +1,4 @@
+[Service]
+Environment='GIO_USE_NETWORK_MONITOR=base'
+ExecStart=
+ExecStart=/usr/libexec/packagekitd --keep-environment


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#10954

PackageKit was failing in Debian templates with the error "Cannot download packages whilst offline" caused by two different problems.

1. PackageKit checks for internet connection using glib's default network monitor (NetworkManager) [1] and reports the network as offline in both Debian and Fedora templates. On Fedora, PackageKit works despite that, as it has a code path to work when it is supposedly offline [2]. On Debian it just fails with the error message mentioned before [3].

2. PackageKit clears the environment.

The fix sets the environment variable GIO_USE_NETWORK_MONITOR=base when starting the packagekit systemd service, reporting it as online. This also requires using the packagekitd --keep-environment argument to "Don't clear environment on startup", according to packagekitd --help.

This fix makes it possible to install deb packages in Debian templates using pkcon, Gnome Software and KDE Discover.

[1] - https://github.com/PackageKit/PackageKit/blob/f3c049c/src/pk-backend.c#L856-L861
[2] - https://github.com/PackageKit/PackageKit/blob/b864c3a/backends/dnf5/dnf5-backend-utils.cpp#L112
[3] - https://github.com/PackageKit/PackageKit/blob/f3c049c/backends/apt/pk-backend-apt.cpp#L515