### PR TITLE
Remove PackageKit's ProxyHTTP (dead code)

### DIFF
--- a/network/update-proxy-configs
+++ b/network/update-proxy-configs
@@ -170,11 +170,6 @@ if [ -e /etc/dnf/dnf.conf ]; then
     update_conf /etc/dnf/dnf.conf "$PROXY_CONF_ENTRY"
 fi
 
-# The same goes for PackageKit...
-# https://bugs.freedesktop.org/show_bug.cgi?id=96788
-if [ -e /etc/PackageKit/PackageKit.conf ]; then
-    update_conf /etc/PackageKit/PackageKit.conf "ProxyHTTP=$PROXY_ADDR"
-fi
 
 # Portage (Gentoo)
 if [ -e /etc/portage/make.conf ]; then


### PR DESCRIPTION
The removed code has no effect providing proxy in PackageKit as it seems ProxyHTTP is no longer an option in PackageKit.conf since PackageKit v 0.8.14 (https://github.com/PackageKit/PackageKit/commit/3afcfcd).

Tested in clean Fedora-43 (PackageKit-1.3.6-1) and Debian-13 (packagekit 1.3.1-1). It was confirmed that removing this code had no effect on installing packages from pkcon or gnome-software.