### PR TITLE
Better wait for network uplink

### DIFF
--- a/qubes-rpc/qubes.WaitForNetworkUplink
+++ b/qubes-rpc/qubes.WaitForNetworkUplink
@@ -11,8 +11,8 @@ fi
 
 i=0
 while test $i -le 10; do
-  if systemctl is-active --quiet "qubes-network-uplink@$iface.service"; then
-    ip link show "$iface" | grep "state UP" || exit 4
+  if systemctl is-active --quiet "qubes-network-uplink@$iface.service" &&
+      ip link show "$iface" | grep "state UP"; then
     exit 0
   fi
   sleep 0.3


### PR DESCRIPTION
qubes.WaitForNetworkUplink should wait for network to be completely up.
For that it checks for two things: whether relevant
qubes-network-uplink@ service is "active" and then whether relevant
network iterface is "UP". But, there is a race condition just after
network switch: interface may disappear already, but systemd still
hasn't noticed it. In that case, systemd unit will be active, while
interface will not be "UP" anymore. What should happen, is the service
should wait for systemd to notice and start the service again,
configuring the new interface, but it simply exited with an error in
this case.

Example log of this happening:

    [   39.009722] vif vif-0: xenbus: device forcefully removed from xenstore
    [   39.305470] xen_netfront: backend supports XDP headroom
    [   39.305549] vif vif-0: bouncing transmitted data to zeroed pages

    [   39.217586] qrexec-agent[1105]: 2026-07-17 21:47:35.395 qrexec-agent[1105]: qrexec-agent-data.c:278:handle_new_process_common: executed: root:QUBESRPC qubes.WaitForNetworkUplink dom0 (pid 1114)
    ...
    [   40.003229] qrexec-agent[1105]: 2026-07-17 21:47:36.223 qrexec-agent[1105]: qrexec-agent-data.c:314:handle_new_process_common: pid 1114 exited with 4
    [   40.052343] systemd[1]: Stopping qubes-network-uplink@eth0.service - Qubes network uplink (eth0) setup...
    [   40.130370] systemd[1]: qubes-network-uplink@eth0.service: Deactivated successfully.
    [   40.135065] systemd[1]: Stopped qubes-network-uplink@eth0.service - Qubes network uplink (eth0) setup.
    [   40.209447] systemd[1]: Starting qubes-network-uplink@eth0.service - Qubes network uplink (eth0) setup...
    [   40.501354] systemd-resolved[300]: eth0: Bus client set DNS server list to: 10.139.1.1, 10.139.1.2
    [   40.515630] systemd[1]: Finished qubes-network-uplink@eth0.service - Qubes network uplink (eth0) setup.

Modify the service to continue waiting in this case.
