### PR TITLE
Disable updates and upgrades via Gnome Software

### DIFF
--- a/config-overrides/20_org.gnome.software.qubes.gschema.override
+++ b/config-overrides/20_org.gnome.software.qubes.gschema.override
@@ -1,0 +1,2 @@
+[org.gnome.software]
+allow-updates=false

--- a/config-overrides/Makefile
+++ b/config-overrides/Makefile
@@ -18,5 +18,6 @@ install:
 		20_org.gnome.desktop.wm.preferences.qubes.gschema.override \
 		20_org.gnome.nautilus.qubes.gschema.override \
 		20_org.gnome.settings-daemon.plugins.updates.qubes.gschema.override \
-		20_org.mate.NotificationDaemon.qubes.gschema.override
+		20_org.mate.NotificationDaemon.qubes.gschema.override \
+		20_org.gnome.software.qubes.gschema.override
 	install -D -m 0644 portals.conf $(DESTDIR)/usr/share/xdg-desktop-portal/portals.conf

--- a/debian/qubes-core-agent.gsettings-override
+++ b/debian/qubes-core-agent.gsettings-override
@@ -3,3 +3,6 @@ theme='slider'
 
 [org.freedesktop.ibus.panel]
 show-icon-on-systray=false
+
+[org.gnome.software]
+allow-updates=false

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1077,6 +1077,7 @@ rm -f %{name}-%{version}
 /usr/share/glib-2.0/schemas/20_org.gnome.nautilus.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.mate.NotificationDaemon.qubes.gschema.override
 /usr/share/glib-2.0/schemas/20_org.gnome.desktop.wm.preferences.qubes.gschema.override
+/usr/share/glib-2.0/schemas/20_org.gnome.software.qubes.gschema.override
 /usr/share/xdg-desktop-portal/portals.conf
 %{_mandir}/man1/qvm-*.1*
 # should be owned by systemd-network, but it isn't


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#10984, by disabling upgrades via Gnome Software. When a new Fedora version was available it encouraged users to upgrade the system, which wouldn't work.

It also disables updates via Gnome Software. Updates were already broken as they were done assuming Gnome Software would be able to restart the system, which can't happen in Qubes.

Qubes already has native tools for updates that should be used instead.