### PR TITLE
arch: install Thunar actions with a pacman hook

### DIFF
--- a/archlinux/PKGBUILD.in
+++ b/archlinux/PKGBUILD.in
@@ -269,6 +269,11 @@ package_qubes-vm-thunar() {
         SYSTEM_DROPIN_DIR=/usr/lib/systemd/system \
         USER_DROPIN_DIR=/usr/lib/systemd/user \
         DIST=archlinux
+
+    install -D -m 755 "archlinux/PKGBUILD.qubes-update-thunar" \
+        "$pkgdir/usr/lib/qubes/update-thunar-actions"
+    install -D -m 644 "archlinux/PKGBUILD.qubes-update-thunar.hook" \
+        "$pkgdir/usr/share/libalpm/hooks/qubes-update-thunar.hook"
 }
 
 package_qubes-vm-nautilus() {

--- a/archlinux/PKGBUILD.qubes-update-thunar
+++ b/archlinux/PKGBUILD.qubes-update-thunar
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+uca_file=/etc/xdg/Thunar/uca.xml
+
+if [ -f "$uca_file" ]; then
+    cp -p "$uca_file" "$uca_file.bak"
+    #shellcheck disable=SC2016
+    sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' "$uca_file"
+fi

--- a/archlinux/PKGBUILD.qubes-update-thunar
+++ b/archlinux/PKGBUILD.qubes-update-thunar
@@ -4,7 +4,8 @@ set -e
 
 uca_file=/etc/xdg/Thunar/uca.xml
 
-if [ -f "$uca_file" ]; then
+if [ -f "$uca_file" ] && \
+        ! grep -qF '<unique-id>1507455450991127-4</unique-id>' "$uca_file"; then
     cp -p "$uca_file" "$uca_file.bak"
     #shellcheck disable=SC2016
     sed -i '$e cat /usr/lib/qubes/uca_qubes.xml' "$uca_file"

--- a/archlinux/PKGBUILD.qubes-update-thunar.hook
+++ b/archlinux/PKGBUILD.qubes-update-thunar.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Operation = Install
+Operation = Upgrade
+Type = Package
+Target = qubes-vm-thunar
+
+[Action]
+Description = Updating Thunar custom actions...
+When = PostTransaction
+Exec = /usr/lib/qubes/update-thunar-actions


### PR DESCRIPTION
Fixes QubesOS/qubes-issues#9740

Arch Linux installs the Qubes Thunar actions under `/usr/lib/qubes/uca_qubes.xml`, but Thunar only loads system custom actions from `/etc/xdg/Thunar/uca.xml`. Add a package-specific pacman post-transaction hook that appends the Qubes actions after `qubes-vm-thunar` is installed or upgraded, matching the existing Debian and Fedora packaging behavior.

This pull request was prepared with AI assistance.