### PR TITLE
Disable /rw/config/rc.local-early if custom-persist is enabled

### DIFF
--- a/vm-systemd/qubes-early-vm-config.sh
+++ b/vm-systemd/qubes-early-vm-config.sh
@@ -4,16 +4,18 @@
 # It happens after local-fs.target is reached
 # but before sysinit.target is reached.
 
-for rc in /rw/config/rc.local-early.d/*.rc /rw/config/rc.local-early; do
-    [ -f "$rc" ] || continue
-    [ -x "$rc" ] || continue
-    "$rc"
-done
-unset rc
-
 # Source Qubes library.
 # shellcheck source=init/functions
 . /usr/lib/qubes/init/functions
+
+if ! is_custom_persist_enabled; then
+    for rc in /rw/config/rc.local-early.d/*.rc /rw/config/rc.local-early; do
+        [ -f "$rc" ] || continue
+        [ -x "$rc" ] || continue
+        "$rc"
+    done
+    unset rc
+fi
 
 # Set the hostname
 if ! is_protected_file /etc/hostname ; then


### PR DESCRIPTION
Custom-persist feature is supposed to disable using files out of /rw
except explicitly enabled. Initial commit handled /rw/config/rc.local,
but missed /rw/config/rc.local-early. Fix it now.

While this allows bypassing custom-persist feature, it isn't considered
security issue, only functional issue. See documentation for details:
https://doc.qubes-os.org/en/r4.3/user/templates/templates.html#note-on-treating-app-qubes-root-filesystem-non-persistence-as-a-security-feature
For secure non-persistent qubes, the correct approach is to use a
disposable, which eliminates way more way more potential persistence
methods (including attacking kernel filesystem driver for example).

Reported-by: Thiago Pereira (@B1gN0Se) via SecureDrop bug bounty

https://github.com/QubesOS/qubes-issues/issues/1006