### PR TITLE
Make vmname argument optional in qvm-open-in-vm

### DIFF
--- a/doc/vm-tools/qvm-open-in-vm.rst
+++ b/doc/vm-tools/qvm-open-in-vm.rst
@@ -8,8 +8,11 @@ qvm-open-in-vm - open a specified file or URL in a other VM
 
 SYNOPSIS
 ========
-| qvm-open-in-vm vmname filename
-| qvm-open-in-vm vmname URL
+| qvm-open-in-vm [vmname] filename
+| qvm-open-in-vm [vmname] URL
+
+If *vmname* is omitted, it defaults to ``@default`` and the qrexec policy
+decides which VM the file or URL is opened in.
 
 OPTIONS
 =======

--- a/qubes-rpc/qvm-open-in-vm
+++ b/qubes-rpc/qvm-open-in-vm
@@ -30,7 +30,7 @@ usage() {
     (qvm-open-in-dvm|*/qvm-open-in-dvm)
         printf 'Usage: %s [--view-only] [--] filename\n' "$0" >&2
         ;;
-    (*) printf 'Usage: %s [--view-only] [--] vmname filename\n' "$0";;
+    (*) printf 'Usage: %s [--view-only] [--] [vmname] filename\n' "$0";;
     esac >&2
     exit "${1-2}"
 }
@@ -59,6 +59,16 @@ for i; do
     fi
 done
 set +u
+
+case $0 in
+(qvm-open-in-dvm|*/qvm-open-in-dvm) ;;
+(*)
+    if [ -n "${target+x}" ] && [ -z "${filename+x}" ]; then
+        filename="$target"
+        target=@default
+    fi
+    ;;
+esac
 
 if [ -z "$target" ] || [ -z "$filename" ]; then
     usage


### PR DESCRIPTION
When `qvm-open-in-vm` is invoked with a single positional argument, it is now treated as the filename (or URL) and the target is set to `@default`, so the qrexec policy decides which VM the file is opened in. This mirrors how the same script invoked as `qvm-open-in-dvm` presets the target to `@dispvm` (as suggested by @rustybird in the issue).

Fixes QubesOS/qubes-issues#11026
