### PR TITLE
fix: use neutral Tinyproxy response pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ install-netvm: install-systemd-networking-dropins install-networkmanager
 	install -D network/vif-qubes-nat.sh $(DESTDIR)/etc/xen/scripts/vif-qubes-nat.sh
 	install -m 0644 -D network/tinyproxy-updates.conf $(DESTDIR)/etc/tinyproxy/tinyproxy-updates.conf
 	install -m 0644 -D network/updates-blacklist $(DESTDIR)/etc/tinyproxy/updates-blacklist
+	install -m 0644 -D network/tinyproxy-neutral.html $(DESTDIR)/usr/share/qubes/tinyproxy-neutral.html
 
 	install -m 0400 -D network/qubes-ipv4.nft $(DESTDIR)/etc/qubes/qubes-ipv4.nft
 	install -m 0400 -D network/qubes-ipv6.nft $(DESTDIR)/etc/qubes/qubes-ipv6.nft

--- a/debian/qubes-core-agent-networking.install
+++ b/debian/qubes-core-agent-networking.install
@@ -9,6 +9,7 @@ etc/sysctl.d/81-qubes.conf.optional
 etc/sysctl.d/82-qubes-minimal-sys-net.conf.optional
 etc/tinyproxy/tinyproxy-updates.conf
 etc/tinyproxy/updates-blacklist
+usr/share/qubes/tinyproxy-neutral.html
 etc/udev/rules.d/99-qubes-network.rules
 etc/xen/scripts/vif-qubes-nat.sh
 etc/xen/scripts/vif-route-qubes

--- a/network/tinyproxy-neutral.html
+++ b/network/tinyproxy-neutral.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Proxy response</title>
+</head>
+<body>
+  <p>No information is available.</p>
+</body>
+</html>

--- a/network/tinyproxy-updates.conf
+++ b/network/tinyproxy-updates.conf
@@ -2,10 +2,13 @@ User tinyproxy
 Group tinyproxy
 Port 8082
 Timeout 60
+# Keep this path customizable by downstream packages.  In particular, Whonix
+# replaces this page with a marker used to verify that updates are Tor-routed.
 DefaultErrorFile "/usr/share/tinyproxy/default.html"
 
 #StatHost "tinyproxy.stats"
-StatFile "/usr/share/tinyproxy/stats.html"
+# Avoid exposing proxy statistics and the Tinyproxy version to other VMs.
+StatFile "/usr/share/qubes/tinyproxy-neutral.html"
 Syslog On
 LogLevel Notice
 PidFile "/var/run/tinyproxy-updates/tinyproxy.pid"

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -1154,6 +1154,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes/rpc-config/qubes.UpdatesProxy
 %config(noreplace) /etc/tinyproxy/tinyproxy-updates.conf
 %config(noreplace) /etc/tinyproxy/updates-blacklist
+/usr/share/qubes/tinyproxy-neutral.html
 %config(noreplace) /etc/udev/rules.d/99-qubes-network.rules
 %if !0%{?is_opensuse}
 /etc/dhclient.d/qubes-setup-dnat-to-ns.sh


### PR DESCRIPTION
## Summary

- route Tinyproxy default error and statistics pages to a neutral response
- install the page through the generic, Debian, and RPM packaging paths

AI assistance disclosure: AI assistance was used to help prepare this pull request.

Fixes QubesOS/qubes-issues#10865.