### PR TITLE
misc: avoid malformed MIME cache for catch-all glob

### DIFF
--- a/misc/mime/packages/qubes-os.org.xml
+++ b/misc/mime/packages/qubes-os.org.xml
@@ -64,7 +64,10 @@ command to generate the output files.
 <mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
   <mime-type type="application/qubes-untrusted-file">
     <comment>Untrusted file to open in a DispVM</comment>
-    <glob pattern="*" weight="100"/>
+    <!-- Filenames are non-empty, so "?*" remains a catch-all while avoiding
+         the empty-suffix bug in shared-mime-info:
+         https://gitlab.freedesktop.org/xdg/shared-mime-info/-/issues/230 -->
+    <glob pattern="?*" weight="100"/>
   </mime-type>
   <mime-type type="image/svg+xml">
     <comment>SVG image</comment>


### PR DESCRIPTION
## Summary

Replace the `*` catch-all glob for `application/qubes-untrusted-file` with `?*` to make the generated MIME cache reproducible.

## Background

`update-mime-database` stores suffix globs in a reverse suffix tree inside `mime.cache`. The existing `*` pattern has an empty suffix and triggers [shared-mime-info#230](https://gitlab.freedesktop.org/xdg/shared-mime-info/-/issues/230), producing a malformed, unlinked tree node whose contents can vary between builds. This causes otherwise identical packages to differ.

Shared MIME glob patterns use `fnmatch(3)` syntax. `?*` matches one or more characters, which is equivalent to `*` for valid, non-empty filenames. Because it is handled as a general glob instead of an empty suffix, it bypasses the broken suffix-tree path while preserving the weight-100 fallback behavior.

Fixes QubesOS/qubes-issues#9159.