### PR TITLE
qvm-run-vm: preserve command options

### DIFF
--- a/qubes-rpc/qvm-run-vm
+++ b/qubes-rpc/qvm-run-vm
@@ -42,7 +42,7 @@ USAGE
 }
 
 
-if ! OPTS=$(getopt -o htd --long help,no-gui,dispvm -n "$0" -- "$@"); then
+if ! OPTS=$(getopt -o +htd --long help,no-gui,dispvm -n "$0" -- "$@"); then
     print_usage
     exit 1
 fi


### PR DESCRIPTION
Stop getopt from parsing options after the VM name. This keeps flags such as `ps -lax` in the command passed to the target qube. 

Fixes QubesOS/qubes-issues#9123 

Discussion on the issue seemed to indicate this change would be the fix, and indeed it is. 

AI assistance:
I used Codex to help develop and test this change. I reviewed the final patch and take responsibility for it.