### PR TITLE
qfile-unpacker: fix concurrent mount/unmount race via flock (#5950)

### DIFF
--- a/qubes-rpc/qfile-unpacker.c
+++ b/qubes-rpc/qfile-unpacker.c
@@ -1,9 +1,14 @@
+#include <asm-generic/errno.h>
 #define _GNU_SOURCE
 #include <grp.h>
 #include <unistd.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <pwd.h>
+#include <sys/file.h>
+#include <libgen.h>
+#include <errno.h>
+#include <stdbool.h>
 #include <sys/stat.h>
 #include <sys/mount.h>
 #include <sys/wait.h>
@@ -93,6 +98,22 @@ uid_t parse_uid(const char *user)
             errno != 0 || *end != '\0' || uid != u)
         gui_fatal("Invalid user ID argument");
     return uid;
+}
+
+bool is_mounted(const char *abs_path, int parent_fd)
+{
+    struct statx stx_self, stx_parent;
+
+    if (statx(AT_FDCWD, abs_path, 0, STATX_MNT_ID, &stx_self))
+      gui_fatal("statx for directory failed");
+    
+    if (statx(parent_fd, "", AT_EMPTY_PATH, STATX_MNT_ID, &stx_parent))
+      gui_fatal("statx for parent directory failed");
+
+    if (!(stx_self.stx_mask & STATX_MNT_ID))
+        gui_fatal("STATX_MNT_ID not populated, kernel may not support it");
+
+    return (stx_self.stx_mnt_id != stx_parent.stx_mnt_id);
 }
 
 int main(int argc, char ** argv)
@@ -200,11 +221,63 @@ int main(int argc, char ** argv)
         mkdir(incoming_dir, 0700);
     }
 
+    char *incoming_dir_abs_path = realpath(incoming_dir, NULL);
+
+    if (incoming_dir_abs_path == NULL)
+      gui_fatal("Could not resolve absolute path to directory %s", incoming_dir);
+    
     if (chdir(incoming_dir))
         gui_fatal("Error chdir to %s", incoming_dir);
 
-    if (mount(".", ".", NULL, MS_BIND | MS_NODEV | MS_NOEXEC | MS_NOSUID, NULL) < 0)
-        gui_fatal("Failed to mount a directory %s", incoming_dir);
+    int incoming_dir_fd = open(incoming_dir_abs_path, O_RDONLY);
+
+    if (incoming_dir_fd < 0)
+        gui_fatal("Failed to open directory %s", incoming_dir);
+
+    int incoming_dir_parent_fd = openat(incoming_dir_fd, "..", O_RDONLY);
+
+    if (incoming_dir_parent_fd < 0)
+        gui_fatal("Failed to open parent directory");
+
+    if (flock(incoming_dir_fd, LOCK_EX | LOCK_NB) == 0) {
+      if (is_mounted(incoming_dir_abs_path, incoming_dir_parent_fd)) {
+          if (flock(incoming_dir_fd, LOCK_SH) < 0)
+            gui_fatal("Failed to downgrade lock on directory %s", incoming_dir);
+      } else {
+          if (mount(incoming_dir_abs_path, incoming_dir_abs_path, NULL,MS_BIND | MS_NODEV | MS_NOEXEC | MS_NOSUID, NULL) < 0)
+            gui_fatal("Failed to mount a directory %s", incoming_dir);
+          if (flock(incoming_dir_fd, LOCK_SH) < 0)
+            gui_fatal("Failed to downgrade lock on directory %s", incoming_dir);
+      }
+    } else {
+        if (errno != EWOULDBLOCK)
+          gui_fatal("Could not acquire lock on directory %s", incoming_dir);
+
+        for (;;) {
+          if (flock(incoming_dir_fd, LOCK_SH) < 0)
+            gui_fatal("Failed to acquire shared lock on directory %s", incoming_dir);
+
+          if (is_mounted(incoming_dir_abs_path, incoming_dir_parent_fd))
+            break;
+
+          if (flock(incoming_dir_fd, LOCK_UN) < 0)
+            gui_fatal("Failed to release lock on directory %s", incoming_dir);
+
+          if (flock(incoming_dir_fd, LOCK_EX | LOCK_NB) == 0) {
+            if (is_mounted(incoming_dir_abs_path, incoming_dir_parent_fd)) {
+                if (flock(incoming_dir_fd, LOCK_SH) < 0)
+                    gui_fatal("Failed to downgrade lock on directory %s", incoming_dir);
+            } else {
+                if (mount(incoming_dir_abs_path, incoming_dir_abs_path, NULL,MS_BIND | MS_NODEV | MS_NOEXEC | MS_NOSUID, NULL) < 0)
+                    gui_fatal("Failed to mount a directory %s", incoming_dir);
+                if (flock(incoming_dir_fd, LOCK_SH) < 0)
+                    gui_fatal("Failed to downgrade lock on directory %s", incoming_dir);
+              }
+            break;
+          } else if (errno != EWOULDBLOCK)
+              gui_fatal("Failed to acquire lock on directory %s", incoming_dir);
+        }
+      }
 
     /* parse the input in unprivileged child process, parent will hold root
      * access to unmount incoming dir */
@@ -234,8 +307,21 @@ int main(int argc, char ** argv)
     if (waitpid(pid, &ret, 0) < 0) {
         gui_fatal("Failed to wait for child process");
     }
-    if (umount2(".", MNT_DETACH) < 0)
+
+    if (flock(incoming_dir_fd, LOCK_UN) < 0)
+      gui_fatal("Failed to release lock on directory %s", incoming_dir);
+
+    if (flock(incoming_dir_fd, LOCK_EX) < 0)
+      gui_fatal("Failed to acquire lock on directory %s", incoming_dir);
+
+    if (is_mounted(incoming_dir_abs_path, incoming_dir_parent_fd)) {
+      if (umount2(incoming_dir_abs_path, MNT_DETACH) < 0)
         gui_fatal("Cannot umount incoming directory");
+    }
+
+    close(incoming_dir_fd);
+    close(incoming_dir_parent_fd);
+
     if (!WIFEXITED(ret)) {
         gui_fatal("Child process exited abnormally");
     }


### PR DESCRIPTION
Fixes QubesOS/qubes-issues/issues/5950

## Problem

When two `qvm-copy` operations to the same target VM run concurrently,
each invocation of `qfile-unpacker` independently bind-mounts and later
unmounts `incoming_dir`. Since both mounts stack at the same path in
the same mount namespace, `umount2()` can remove the wrong process's mount layer, causing:

  `  qfile-unpacker: Fatal error: Cannot umount incoming directory
    (error type: Invalid argument) `

## Fix

Instead of every invocation independently mounting and unmounting,
coordinate via flock() on incoming_dir itself :

- Each worker holds a LOCK_SH on incoming_dir for its entire lifetime.
- On entry: attempt LOCK_EX (non-blocking). Winner checks whether
  already mounted, mounts if not, downgrades to LOCK_SH. Loser blocks
  on LOCK_SH (waiting for the current holder's mount decision), then
  re-checks mount state, if still unmounted then releases SH and retries EX.
- On exit: release LOCK_SH, blocking-acquire LOCK_EX, check
  mount state, unmount only if still mounted.

- Crash safety comes from flock() itself since kernel cleans up after a process dies.

- mount()/umount2() use the resolved absolute path throughout, since a process's "." can end up resolving through an lazily-detached mount reference.

## Testing

Validated qfile-unpacker.c linked
against minimal local stubs of gui-fatal.h/libqubes-rpc-filecopy.h
(do_unpack_ext replaced with a sleep to simulate copy duration, no
change to any mount/lock logic under test).

Tested with N=64 concurrent qfile-unpacker, invocations and numerous iterations with varied timings:

- Normal timing: clean, 0 failures.
- --copy-us 0 (max mount/unmount churn): 0 incorrect outcomes. Some
  iterations show >1 mount/unmount cycle per batch (late joiner races a
  teardown) expected self-healing.
- Random SIGKILL fault injection, incl. pre-mount-completion kills:
  recovers correctly every time.

## Important Notes 
The mount-status check uses statx(STATX_MNT_ID), which requires kernel
5.8+. I haven't been able to confirm Qubes' actual minimum supported
kernel floor for VMs/templates.

## AI disclosure

Used Claude among some other models to discuss, research and write tests against my proposed fixes and review the final file before the files were reviewed and verified by me.