### PR TITLE
qubes-rpc: add qubes.PostUpdate hook for every update run

### DIFF
--- a/debian/qubes-core-agent.install
+++ b/debian/qubes-core-agent.install
@@ -21,6 +21,7 @@ etc/qubes-rpc/qubes.Log
 etc/qubes-rpc/qubes.OpenInVM
 etc/qubes-rpc/qubes.OpenURL
 etc/qubes-rpc/qubes.PostInstall
+etc/qubes-rpc/qubes.PostUpdate
 etc/qubes-rpc/qubes.RegisterBackupLocation
 etc/qubes-rpc/qubes.ResizeDisk
 etc/qubes-rpc/qubes.RestoreById
@@ -47,6 +48,7 @@ etc/qubes/autostart/*
 etc/qubes/applications/*
 etc/qubes/post-install.d/README
 etc/qubes/post-install.d/*.sh
+etc/qubes/post-update.d/README
 etc/qubes/rpc-config/qubes.ConnectTCP
 etc/qubes/rpc-config/qubes.OpenInVM
 etc/qubes/rpc-config/qubes.OpenURL

--- a/qubes-rpc/Makefile
+++ b/qubes-rpc/Makefile
@@ -93,6 +93,7 @@ install:
 		qubes.ResizeDisk \
 		qubes.StartApp \
 		qubes.PostInstall \
+		qubes.PostUpdate \
 		qubes.GetDate \
 		qubes.ShowInTerminal \
 		qubes.TemplateSearch \
@@ -114,3 +115,5 @@ install:
 	install -d $(DESTDIR)/etc/qubes/post-install.d
 	install -t $(DESTDIR)$(QUBESCONFDIR)/post-install.d -m 0644 post-install.d/README
 	install -t $(DESTDIR)$(QUBESCONFDIR)/post-install.d post-install.d/*.sh
+	install -d $(DESTDIR)/etc/qubes/post-update.d
+	install -t $(DESTDIR)$(QUBESCONFDIR)/post-update.d -m 0644 post-update.d/README

--- a/qubes-rpc/post-update.d/README
+++ b/qubes-rpc/post-update.d/README
@@ -1,0 +1,8 @@
+All executable files with `.sh` suffix in this directory will be executed as
+root by qubes-vm-update after the distribution package manager has finished in
+a TemplateVM or StandaloneVM, regardless of whether any package was installed,
+updated or removed. The updates proxy is available at this time. A failing
+script does not stop the others, but qubes-vm-update reports the failure.
+
+For actions that should only run when packages were actually installed or
+updated, use /etc/qubes/post-install.d instead.

--- a/qubes-rpc/qubes.PostUpdate
+++ b/qubes-rpc/qubes.PostUpdate
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# The Qubes OS Project, http://www.qubes-os.org
+#
+# Copyright (C) 2026  Andreas Glashauser <ag@andreasglashauser.com>
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+#
+
+# run every hook even if one fails, but still report the failure
+status=0
+for script in /etc/qubes/post-update.d/*.sh; do
+    if [ -x "$script" ]; then
+        "$script" || status=1
+    fi
+done
+exit $status

--- a/rpm_spec/core-agent.spec.in
+++ b/rpm_spec/core-agent.spec.in
@@ -941,6 +941,7 @@ rm -f %{name}-%{version}
 %config(noreplace) /etc/qubes-rpc/qubes.ResizeDisk
 %config(noreplace) /etc/qubes-rpc/qubes.StartApp
 %config(noreplace) /etc/qubes-rpc/qubes.PostInstall
+%config(noreplace) /etc/qubes-rpc/qubes.PostUpdate
 %config(noreplace) /etc/qubes-rpc/qubes.GetDate
 %config(noreplace) /etc/qubes/rpc-config/qubes.ConnectTCP
 %config(noreplace) /etc/qubes/rpc-config/qubes.OpenInVM
@@ -979,6 +980,8 @@ rm -f %{name}-%{version}
 %dir /etc/qubes/post-install.d
 /etc/qubes/post-install.d/README
 /etc/qubes/post-install.d/*.sh
+%dir /etc/qubes/post-update.d
+/etc/qubes/post-update.d/README
 %config(noreplace) /etc/profile.d/qt_x11_no_mitshm.sh
 %config(noreplace) /etc/profile.d/zqubes_disable_lesspipe.sh
 %config(noreplace) /etc/sudoers.d/qt_x11_no_mitshm


### PR DESCRIPTION
This adds `/etc/qubes-rpc/qubes.PostUpdate`, which runs every executable script in `/etc/qubes/post-update.d`, plus the directory and a `README` describing the contract. scripts run as root after `qubes-vm-update` finished the package manager in a template or standalone VM, whether or not any package was installed. A failing script does not stop the others, but the exit status is non-zero so the agent can report it.

AI disclosure: I used a local LLM for writing commit messages. I have written each line of code myself, but I used Claude Fable 5 to brainstorm an implementation plan and review my code. Also the README was written by Fable.

Relates to https://github.com/QubesOS/qubes-issues/issues/10389